### PR TITLE
Align ports to the three-mode registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: andy_rbac
     ports:
-      - "5433:5432"
+      - "7433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/src/Andy.Rbac.Api/Properties/launchSettings.json
+++ b/src/Andy.Rbac.Api/Properties/launchSettings.json
@@ -1,10 +1,19 @@
 {
   "profiles": {
-    "Andy.Rbac.Api": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7003;http://localhost:5003",
+      "applicationUrl": "https://localhost:5003;http://localhost:5004",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5004",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Andy.Rbac.Api/appsettings.Development.json
+++ b/src/Andy.Rbac.Api/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
+  "//": "Dev-override for `dotnet run + docker compose up postgres` — points at the Mode 2 docker pg (Mode 1 + 2000). See andy-service-template/docs/ports.md.",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5433;Database=andy_rbac;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=7433;Database=andy_rbac;Username=postgres;Password=postgres"
   },
   "Auth": {
     "Authority": "https://localhost:5001",

--- a/src/Andy.Rbac.Api/appsettings.json
+++ b/src/Andy.Rbac.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=andy_rbac;Username=postgres;Password=postgres;Pooling=true;Minimum Pool Size=0;Maximum Pool Size=100;"
+    "DefaultConnection": "Host=localhost;Port=5433;Database=andy_rbac;Username=postgres;Password=postgres;Pooling=true;Minimum Pool Size=0;Maximum Pool Size=100;"
   },
   "Database": {
     "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables.",


### PR DESCRIPTION
Per rivoli-ai/andy-service-template#2 — three-mode registry. andy-rbac: Mode 1 5003/5004/5433, Mode 2 7003/7004/7433, Mode 3 proxy /rbac.

Changes:
- `launchSettings.json`: single profile with mixed ports (https 7003, http 5003) → proper `https` + `http` profiles at canonical Mode 1 (5003/5004)
- `appsettings.json`: connection-string Port 5432 (postgres default) → 5433 (Mode 1)
- `appsettings.Development.json`: pg 5433 → 7433 (Mode 2 docker override)
- `docker-compose.yml`: postgres 5433 → 7433. The `api` container was already binding 7003/7004 (Mode 2).

Out of scope: `src/Andy.Rbac.Web` (the admin UI) has some drift (Rbac:ApiBaseUrl pointing at :5001 which is andy-auth's port, and its own launchSettings at :5180/:5181 are not in the canonical registry). Filed as a follow-up.

Reviewer note: `docker compose down && docker compose up -d` after merging to rebind pg.

Related: rivoli-ai/andy-service-template#2, rivoli-ai/andy-tasks#9.