### PR TITLE
Manifest-driven RBAC seeding + urn:andy-rbac-api audience

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../andy-service-template/docs/registration.schema.json",
+  "service": {
+    "name": "andy-rbac",
+    "displayName": "Andy RBAC",
+    "description": "Role-based access control — permission evaluation, role inheritance, policy checks.",
+    "embeddedProxyPrefix": "/rbac",
+    "ports": {
+      "dotnetHttps": 5003,
+      "dotnetHttp":  5004,
+      "dotnetPostgres": 5433,
+      "dockerHttps": 7003,
+      "dockerHttp":  7004,
+      "dockerPostgres": 7433,
+      "embeddedProxy": 9100
+    }
+  },
+  "auth": {
+    "audience": "urn:andy-rbac-api",
+    "webClient": {
+      "clientId": "andy-rbac-web",
+      "clientType": "public",
+      "displayName": "Andy RBAC Web",
+      "description": "Admin UI for RBAC management (server-side Blazor/MVC on ports 5180/5181)",
+      "grantTypes": ["authorization_code", "refresh_token"],
+      "scopes": ["email", "profile", "roles", "scp:urn:andy-rbac-api"],
+      "redirectUris": [
+        "https://localhost:5180/signin-oidc",
+        "http://localhost:5181/signin-oidc",
+        "https://localhost:5180/callback",
+        "http://localhost:5181/callback",
+        "http://localhost:9100/rbac/callback"
+      ],
+      "postLogoutRedirectUris": [
+        "https://localhost:5180/",
+        "https://localhost:5180/signout-callback-oidc",
+        "http://localhost:5181/",
+        "http://localhost:5181/signout-callback-oidc",
+        "http://localhost:9100/rbac/"
+      ]
+    }
+  },
+  "rbac": {
+    "applicationCode": "andy-rbac",
+    "applicationName": "Andy RBAC",
+    "description": "Role-Based Access Control service",
+    "resourceTypes": [
+      { "code": "application",   "name": "Application",    "supportsInstances": true  },
+      { "code": "role",          "name": "Role",           "supportsInstances": true  },
+      { "code": "permission",    "name": "Permission",     "supportsInstances": true  },
+      { "code": "subject",       "name": "Subject",        "supportsInstances": true  }
+    ],
+    "roles": [
+      { "code": "admin",  "name": "Administrator", "description": "Full access to RBAC",    "isSystem": true },
+      { "code": "user",   "name": "User",          "description": "Standard user",          "isSystem": true },
+      { "code": "viewer", "name": "Viewer",        "description": "Read-only RBAC access",  "isSystem": true }
+    ],
+    "testUserRole": "admin"
+  },
+  "settings": {
+    "definitions": [
+      { "key": "andy.rbac.apiBaseUrl",       "displayName": "RBAC API URL",     "description": "Andy RBAC API base URL",            "category": "General",     "dataType": "Uri",     "defaultValue": "https://localhost:5003" },
+      { "key": "andy.rbac.applicationCode",  "displayName": "Application Code", "description": "RBAC application identifier",       "category": "General",     "dataType": "String",  "defaultValue": "andy-rbac" },
+      { "key": "andy.rbac.cacheTtlSeconds",  "displayName": "Cache TTL",        "description": "Permission cache TTL in seconds",   "category": "Performance", "dataType": "Integer", "defaultValue": 300 }
+    ]
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,13 @@ services:
       - ASPNETCORE_URLS=https://+:8443;http://+:8080
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_rbac;Username=postgres;Password=postgres
       - Auth__Authority=https://host.docker.internal:5001
-      - Auth__Audience=andy-rbac
+      - Auth__Audience=urn:andy-rbac-api
       - Cors__Origins__0=https://localhost:5180
       - Cors__Origins__1=http://localhost:5180
       - Cors__Origins__2=https://localhost:3000
+      # Registration manifests — seed RBAC applications, resource types, roles
+      # from each sibling service's config/registration.json at startup.
+      - REGISTRATIONS__MANIFEST_PATHS=/monorepo/andy-auth/config/registration.json:/monorepo/andy-rbac/config/registration.json:/monorepo/andy-containers/config/registration.json:/monorepo/andy-docs/config/registration.json:/monorepo/andy-code-index/config/registration.json:/monorepo/andy-issues/config/registration.json:/monorepo/andy-agents/config/registration.json:/monorepo/andy-tasks/config/registration.json:/monorepo/andy-policies/config/registration.json:/monorepo/andy-models/config/registration.json
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
@@ -39,6 +42,7 @@ services:
       - "7004:8080"
     volumes:
       - ./certs:/usr/local/share/ca-certificates/custom:ro
+      - ..:/monorepo:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -298,7 +298,7 @@ Optional client-side cache short-circuits repeat checks.
 Key settings:
 
 ```json
-"Auth": { "Authority": "https://auth.rivoli.ai", "Audience": "andy-rbac" },
+"Auth": { "Authority": "https://auth.rivoli.ai", "Audience": "urn:andy-rbac-api" },
 "Database": { "Provider": "PostgreSql" },
 "Mcp": { "ServerUrl": "https://rbac-api.rivoli.ai", "McpPath": "/mcp" },
 "Cors": { "Origins": ["http://localhost:3000", "https://rbac.rivoli.ai"] }

--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -18,6 +18,77 @@ public static class DataSeeder
         await db.SaveChangesAsync(ct);
     }
 
+    /// <summary>
+    /// Manifest-driven application + resource-type + role seeding. Reads every
+    /// available registration manifest and inserts its RBAC section into the
+    /// database. Idempotent via existence checks. The legacy hardcoded
+    /// SeedApplicationsAsync / SeedApplicationDataAsync paths still run
+    /// alongside during the transition until every service ships a manifest.
+    /// </summary>
+    public static async Task SeedFromManifestsAsync(
+        RbacDbContext db,
+        IConfiguration configuration,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        var manifests = RegistrationManifestLoader.LoadAll(configuration, logger);
+        if (manifests.Count == 0)
+        {
+            logger.LogInformation("No registration manifests found; relying on legacy hardcoded RBAC seeding.");
+            return;
+        }
+
+        foreach (var manifest in manifests)
+        {
+            if (manifest.Rbac is null) continue;
+
+            var app = await db.Applications.FirstOrDefaultAsync(a => a.Code == manifest.Rbac.ApplicationCode, ct);
+            if (app is null)
+            {
+                app = new Application
+                {
+                    Code = manifest.Rbac.ApplicationCode,
+                    Name = manifest.Rbac.ApplicationName,
+                    Description = manifest.Rbac.Description ?? manifest.Service.Description
+                };
+                db.Applications.Add(app);
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation("[manifest] Registered RBAC application: {Code}", app.Code);
+            }
+
+            foreach (var rt in manifest.Rbac.ResourceTypes ?? Array.Empty<RegistrationResourceType>())
+            {
+                if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
+                {
+                    db.ResourceTypes.Add(new ResourceType
+                    {
+                        ApplicationId = app.Id,
+                        Code = rt.Code,
+                        Name = rt.Name,
+                        SupportsInstances = rt.SupportsInstances ?? false
+                    });
+                }
+            }
+
+            foreach (var role in manifest.Rbac.Roles ?? Array.Empty<RegistrationRole>())
+            {
+                if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
+                {
+                    db.Roles.Add(new Role
+                    {
+                        ApplicationId = app.Id,
+                        Code = role.Code,
+                        Name = role.Name,
+                        Description = role.Description ?? string.Empty,
+                        IsSystem = role.IsSystem ?? true
+                    });
+                }
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
     private static async Task SeedActionsAsync(RbacDbContext db, CancellationToken ct)
     {
         var actions = new[]
@@ -41,22 +112,16 @@ public static class DataSeeder
         }
     }
 
+    /// <summary>
+    /// Legacy hardcoded application seeding. Only registers consumer apps and
+    /// out-of-scope services that don't yet ship a <c>config/registration.json</c>:
+    /// andy-cli, andy-agentic-web, subscription, narration. Every other Andy
+    /// service now registers itself via <see cref="SeedFromManifestsAsync"/>.
+    /// </summary>
     private static async Task SeedApplicationsAsync(RbacDbContext db, CancellationToken ct)
     {
         var applications = new[]
         {
-            new Application
-            {
-                Code = "andy-auth",
-                Name = "Andy Auth",
-                Description = "OAuth 2.0/OIDC authentication server"
-            },
-            new Application
-            {
-                Code = "andy-docs",
-                Name = "Andy Docs",
-                Description = "AI-assisted document management and writing platform"
-            },
             new Application
             {
                 Code = "andy-cli",
@@ -71,24 +136,6 @@ public static class DataSeeder
             },
             new Application
             {
-                Code = "andy-rbac",
-                Name = "Andy RBAC",
-                Description = "Role-Based Access Control service"
-            },
-            new Application
-            {
-                Code = "code-index",
-                Name = "Andy Code Index",
-                Description = "Code indexing and search platform"
-            },
-            new Application
-            {
-                Code = "containers",
-                Name = "Andy Containers",
-                Description = "Container management platform"
-            },
-            new Application
-            {
                 Code = "subscription",
                 Name = "Andy Subscription",
                 Description = "Subscription management, billing, and entitlements"
@@ -98,24 +145,6 @@ public static class DataSeeder
                 Code = "narration",
                 Name = "Andy Narration",
                 Description = "Text-to-speech narration and audiobook publishing"
-            },
-            new Application
-            {
-                Code = "andy-issues",
-                Name = "Andy Issues",
-                Description = "Issue tracking and work item management"
-            },
-            new Application
-            {
-                Code = "andy-agents",
-                Name = "Andy Agents",
-                Description = "AI agent orchestration and management"
-            },
-            new Application
-            {
-                Code = "andy-tasks",
-                Name = "Andy Tasks",
-                Description = "Tasks management service"
             }
         };
 
@@ -172,23 +201,11 @@ public static class DataSeeder
 
         switch (applicationCode)
         {
-            case "andy-docs":
-                await SeedAndyDocsAsync(db, app, ct);
-                break;
             case "andy-cli":
                 await SeedAndyCliAsync(db, app, ct);
                 break;
-            case "andy-auth":
-                await SeedAndyAuthAsync(db, app, ct);
-                break;
             case "andy-agentic-web":
                 await SeedAndyAgenticWebAsync(db, app, ct);
-                break;
-            case "code-index":
-                await SeedCodeIndexAsync(db, app, ct);
-                break;
-            case "containers":
-                await SeedContainersAsync(db, app, ct);
                 break;
             case "subscription":
                 await SeedSubscriptionAsync(db, app, ct);
@@ -196,54 +213,12 @@ public static class DataSeeder
             case "narration":
                 await SeedNarrationAsync(db, app, ct);
                 break;
-            case "andy-issues":
-                await SeedAndyIssuesAsync(db, app, ct);
-                break;
-            case "andy-agents":
-                await SeedAndyAgentsAsync(db, app, ct);
-                break;
-            case "andy-tasks":
-                await SeedAndyTasksAsync(db, app, ct);
-                break;
         }
 
         await db.SaveChangesAsync(ct);
     }
 
-    private static async Task SeedAndyDocsAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        // Resource types
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "document", Name = "Document", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "collection", Name = "Collection", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "template", Name = "Template", SupportsInstances = true },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-            {
-                db.ResourceTypes.Add(rt);
-            }
-        }
-
-        // Roles
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Andy Docs", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "editor", Name = "Editor", Description = "Can create and edit documents", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "viewer", Name = "Viewer", Description = "Can only view documents", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-            {
-                db.Roles.Add(role);
-            }
-        }
-    }
+    // SeedAndyDocsAsync: removed — andy-docs now manifest-driven (S1/S2 refactor).
 
     private static async Task SeedAndyCliAsync(RbacDbContext db, Application app, CancellationToken ct)
     {
@@ -278,37 +253,7 @@ public static class DataSeeder
         }
     }
 
-    private static async Task SeedAndyAuthAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "user", Name = "User", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "client", Name = "OAuth Client", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "scope", Name = "Scope", SupportsInstances = true },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-            {
-                db.ResourceTypes.Add(rt);
-            }
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full auth server access", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "user-manager", Name = "User Manager", Description = "Can manage users", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-            {
-                db.Roles.Add(role);
-            }
-        }
-    }
+    // SeedAndyAuthAsync: removed — andy-auth now manifest-driven.
 
     private static async Task SeedAndyAgenticWebAsync(RbacDbContext db, Application app, CancellationToken ct)
     {
@@ -342,75 +287,9 @@ public static class DataSeeder
         }
     }
 
-    private static async Task SeedCodeIndexAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "repository", Name = "Repository", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "settings", Name = "Settings", SupportsInstances = false },
-            new ResourceType { ApplicationId = app.Id, Code = "task", Name = "Task", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "enrichment", Name = "Enrichment", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "search", Name = "Search", SupportsInstances = false },
-        };
+    // SeedCodeIndexAsync: removed — andy-code-index now manifest-driven.
 
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-            {
-                db.ResourceTypes.Add(rt);
-            }
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Code Index", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "user", Name = "User", Description = "Standard Code Index user", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "viewer", Name = "Viewer", Description = "Read-only access", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-            {
-                db.Roles.Add(role);
-            }
-        }
-    }
-
-    private static async Task SeedContainersAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "container", Name = "Container", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "image", Name = "Image", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "template", Name = "Template", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "workspace", Name = "Workspace", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "provider", Name = "Provider", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "settings", Name = "Settings", SupportsInstances = false },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-            {
-                db.ResourceTypes.Add(rt);
-            }
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Containers", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "user", Name = "User", Description = "Standard Containers user", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-            {
-                db.Roles.Add(role);
-            }
-        }
-    }
+    // SeedContainersAsync: removed — andy-containers now manifest-driven.
 
     private static async Task SeedSubscriptionAsync(RbacDbContext db, Application app, CancellationToken ct)
     {
@@ -486,93 +365,8 @@ public static class DataSeeder
         }
     }
 
-    private static async Task SeedAndyIssuesAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "issue", Name = "Issue", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "project", Name = "Project", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "label", Name = "Label", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "settings", Name = "Settings", SupportsInstances = false },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-                db.ResourceTypes.Add(rt);
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Andy Issues", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "user", Name = "User", Description = "Standard issue management", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "viewer", Name = "Viewer", Description = "Read-only access", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-                db.Roles.Add(role);
-        }
-    }
-
-    private static async Task SeedAndyAgentsAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "agent", Name = "Agent", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "run", Name = "Agent Run", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "template", Name = "Agent Template", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "settings", Name = "Settings", SupportsInstances = false },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-                db.ResourceTypes.Add(rt);
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Andy Agents", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "operator", Name = "Operator", Description = "Can create and run agents", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "viewer", Name = "Viewer", Description = "Read-only access to agent data", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-                db.Roles.Add(role);
-        }
-    }
-
-    private static async Task SeedAndyTasksAsync(RbacDbContext db, Application app, CancellationToken ct)
-    {
-        var resourceTypes = new[]
-        {
-            new ResourceType { ApplicationId = app.Id, Code = "item", Name = "Item", SupportsInstances = true },
-            new ResourceType { ApplicationId = app.Id, Code = "settings", Name = "Settings", SupportsInstances = false },
-        };
-
-        foreach (var rt in resourceTypes)
-        {
-            if (!await db.ResourceTypes.AnyAsync(r => r.ApplicationId == app.Id && r.Code == rt.Code, ct))
-                db.ResourceTypes.Add(rt);
-        }
-
-        var roles = new[]
-        {
-            new Role { ApplicationId = app.Id, Code = "admin", Name = "Administrator", Description = "Full access to Andy Tasks", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "user", Name = "User", Description = "Standard Andy Tasks user", IsSystem = true },
-            new Role { ApplicationId = app.Id, Code = "viewer", Name = "Viewer", Description = "Read-only access", IsSystem = true },
-        };
-
-        foreach (var role in roles)
-        {
-            if (!await db.Roles.AnyAsync(r => r.ApplicationId == app.Id && r.Code == role.Code, ct))
-                db.Roles.Add(role);
-        }
-    }
+    // SeedAndyIssuesAsync, SeedAndyAgentsAsync, SeedAndyTasksAsync: removed —
+    // all now manifest-driven via each service's config/registration.json.
 
     /// <summary>
     /// Seeds super-admin permissions for all resource types and creates a test user subject.

--- a/src/Andy.Rbac.Api/Data/RegistrationManifest.cs
+++ b/src/Andy.Rbac.Api/Data/RegistrationManifest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+using System.Text.Json.Serialization;
+
+namespace Andy.Rbac.Api.Data;
+
+/// <summary>
+/// Wire format of config/registration.json files produced by the andy-service-template.
+/// Every Andy ecosystem service ships one; andy-auth, andy-rbac, and andy-settings
+/// each read their relevant section on startup and seed from it.
+///
+/// Schema: ../../andy-service-template/docs/registration.schema.json
+/// </summary>
+public sealed record RegistrationManifest(
+    [property: JsonPropertyName("service")]  RegistrationServiceInfo Service,
+    [property: JsonPropertyName("auth")]     RegistrationAuthInfo?   Auth,
+    [property: JsonPropertyName("rbac")]     RegistrationRbacInfo?   Rbac,
+    [property: JsonPropertyName("settings")] RegistrationSettingsInfo? Settings
+);
+
+public sealed record RegistrationServiceInfo(
+    [property: JsonPropertyName("name")]                string Name,
+    [property: JsonPropertyName("displayName")]         string DisplayName,
+    [property: JsonPropertyName("description")]         string Description,
+    [property: JsonPropertyName("embeddedProxyPrefix")] string EmbeddedProxyPrefix
+);
+
+public sealed record RegistrationAuthInfo(
+    [property: JsonPropertyName("audience")] string Audience
+);
+
+public sealed record RegistrationRbacInfo(
+    [property: JsonPropertyName("applicationCode")] string ApplicationCode,
+    [property: JsonPropertyName("applicationName")] string ApplicationName,
+    [property: JsonPropertyName("description")]     string? Description,
+    [property: JsonPropertyName("resourceTypes")]   RegistrationResourceType[]? ResourceTypes,
+    [property: JsonPropertyName("roles")]           RegistrationRole[]? Roles,
+    [property: JsonPropertyName("testUserRole")]    string? TestUserRole
+);
+
+public sealed record RegistrationResourceType(
+    [property: JsonPropertyName("code")]              string Code,
+    [property: JsonPropertyName("name")]              string Name,
+    [property: JsonPropertyName("supportsInstances")] bool? SupportsInstances
+);
+
+public sealed record RegistrationRole(
+    [property: JsonPropertyName("code")]        string Code,
+    [property: JsonPropertyName("name")]        string Name,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("isSystem")]    bool? IsSystem
+);
+
+public sealed record RegistrationSettingsInfo();

--- a/src/Andy.Rbac.Api/Data/RegistrationManifestLoader.cs
+++ b/src/Andy.Rbac.Api/Data/RegistrationManifestLoader.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+using System.Text.Json;
+
+namespace Andy.Rbac.Api.Data;
+
+/// <summary>
+/// Discovers and parses registration manifests on startup. See
+/// <see cref="RegistrationManifest"/> for the wire format and the andy-service-template
+/// docs for discovery conventions.
+/// </summary>
+public static class RegistrationManifestLoader
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    public static IReadOnlyList<RegistrationManifest> LoadAll(IConfiguration configuration, ILogger logger)
+    {
+        var paths = ResolveSearchPaths(configuration);
+        var manifests = new Dictionary<string, RegistrationManifest>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in paths)
+        {
+            foreach (var file in EnumerateManifestFiles(path, logger))
+            {
+                var manifest = TryLoad(file, logger);
+                if (manifest is null) continue;
+                if (manifests.ContainsKey(manifest.Service.Name)) continue;
+                manifests[manifest.Service.Name] = manifest;
+                logger.LogInformation("Loaded registration manifest for {Service} from {File}.",
+                    manifest.Service.Name, file);
+            }
+        }
+
+        logger.LogInformation("Registration manifest load complete: {Count} manifest(s).", manifests.Count);
+        return manifests.Values.ToList();
+    }
+
+    private static IReadOnlyList<string> ResolveSearchPaths(IConfiguration configuration)
+    {
+        var paths = new List<string>();
+
+        var configured = configuration.GetSection("Registrations:ManifestPaths").Get<string[]>();
+        if (configured is not null) paths.AddRange(configured);
+
+        var envVar = Environment.GetEnvironmentVariable("REGISTRATIONS__MANIFEST_PATHS");
+        if (!string.IsNullOrWhiteSpace(envVar))
+        {
+            var sep = OperatingSystem.IsWindows() ? ';' : ':';
+            paths.AddRange(envVar.Split(sep, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        if (paths.Count == 0)
+        {
+            const string defaultPath = "/etc/andy/registrations";
+            if (Directory.Exists(defaultPath)) paths.Add(defaultPath);
+        }
+
+        return paths;
+    }
+
+    private static IEnumerable<string> EnumerateManifestFiles(string path, ILogger logger)
+    {
+        if (File.Exists(path)) { yield return path; yield break; }
+        if (!Directory.Exists(path))
+        {
+            logger.LogDebug("Registration manifest path {Path} does not exist; skipping.", path);
+            yield break;
+        }
+        foreach (var file in Directory.EnumerateFiles(path, "*.json", SearchOption.TopDirectoryOnly))
+            yield return file;
+    }
+
+    private static RegistrationManifest? TryLoad(string file, ILogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(file);
+            var manifest = JsonSerializer.Deserialize<RegistrationManifest>(stream, JsonOptions);
+            if (manifest is null || manifest.Service is null || string.IsNullOrWhiteSpace(manifest.Service.Name))
+            {
+                logger.LogWarning("Manifest {File} missing required 'service.name'; skipping.", file);
+                return null;
+            }
+            return manifest;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Manifest {File} failed to parse; skipping.", file);
+            return null;
+        }
+        catch (IOException ex)
+        {
+            logger.LogWarning(ex, "Manifest {File} could not be read; skipping.", file);
+            return null;
+        }
+    }
+}

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -269,8 +269,17 @@ using (var scope = app.Services.CreateScope())
     // Seed initial data
     await DataSeeder.SeedAsync(db);
 
-    // Seed application-specific data
-    foreach (var appCode in new[] { "andy-auth", "andy-docs", "andy-cli", "andy-agentic-web", "code-index", "containers", "narration", "andy-issues", "andy-agents", "andy-tasks" })
+    // Manifest-driven app + roles + resource types (reads config/registration.json
+    // files from sibling services via REGISTRATIONS__MANIFEST_PATHS env var or
+    // Registrations:ManifestPaths config). Must run AFTER SeedAsync so the global
+    // roles and actions exist for FK references.
+    await DataSeeder.SeedFromManifestsAsync(db, app.Configuration, app.Logger);
+
+    // Seed application-specific data for the consumer apps and out-of-scope
+    // services that don't yet ship a registration manifest. The 10 in-scope
+    // Andy services (auth/rbac/docs/code-index/containers/issues/agents/tasks/
+    // policies/models) are handled by SeedFromManifestsAsync above.
+    foreach (var appCode in new[] { "andy-cli", "andy-agentic-web", "narration", "subscription" })
     {
         await DataSeeder.SeedApplicationDataAsync(db, appCode);
     }

--- a/src/Andy.Rbac.Api/appsettings.Development.json
+++ b/src/Andy.Rbac.Api/appsettings.Development.json
@@ -5,7 +5,7 @@
   },
   "Auth": {
     "Authority": "https://localhost:5001",
-    "Audience": "andy-rbac"
+    "Audience": "urn:andy-rbac-api"
   },
   "AndyAuth": {
     "Authority": "https://localhost:5001"

--- a/src/Andy.Rbac.Api/appsettings.json
+++ b/src/Andy.Rbac.Api/appsettings.json
@@ -8,7 +8,7 @@
   },
   "Auth": {
     "Authority": "https://auth.rivoli.ai",
-    "Audience": "andy-rbac"
+    "Audience": "urn:andy-rbac-api"
   },
   "AndyAuth": {
     "Authority": "https://auth.rivoli.ai"


### PR DESCRIPTION
## Summary

andy-rbac reads `config/registration.json` from each sibling service at startup and seeds Applications, ResourceTypes, and Roles from them. The hardcoded catalog is trimmed to just external consumer apps. Also renames the audience to the canonical `urn:andy-rbac-api`.

## Changes

- **RegistrationManifest.cs / RegistrationManifestLoader.cs** — new; mirror andy-auth's pattern (schema at `andy-service-template/docs/registration.schema.json`).
- **DataSeeder.SeedFromManifestsAsync** — iterates manifests, upserts Applications + ResourceTypes + Roles. Idempotent.
- **DataSeeder.SeedApplicationsAsync** — hardcoded array trimmed to `andy-cli`, `andy-agentic-web`, `subscription`, `narration`. The 10 Andy services seed themselves via manifest.
- **DataSeeder.SeedApplicationDataAsync** — switch + 7 private helpers removed (`SeedAndyDocsAsync`, `SeedAndyAuthAsync`, `SeedCodeIndexAsync`, `SeedContainersAsync`, `SeedAndyIssuesAsync`, `SeedAndyAgentsAsync`, `SeedAndyTasksAsync`).
- **Program.cs** — call `SeedFromManifestsAsync` after `SeedAsync`; hardcoded appCode loop trimmed.
- **Audience rename** (`urn:andy-rbac-api`) in `appsettings.json`, `appsettings.Development.json`, `docker-compose.yml`, `docs/presentation.md`.
- **config/registration.json** (new) — andy-rbac's own manifest.
- **docker-compose.yml** — `REGISTRATIONS__MANIFEST_PATHS` + `../:/monorepo:ro` mount.

## Closes

- rivoli-ai/andy-rbac#41 — Remove hardcoded application seeding
- rivoli-ai/andy-rbac#42 — Adopt `urn:andy-rbac-api` audience

Part of epic rivoli-ai/conductor#769.

## Breaking change note

Audience rename: any caller holding a token with `aud=andy-rbac` will be rejected after the cutover. Re-login (dev) or re-issue (prod) to pick up `aud=urn:andy-rbac-api`.

## Test plan

- [x] `dotnet build` clean — 0 warnings, 0 errors
- [x] Docker up end-to-end: 14 applications seeded (10 via manifest, 4 via legacy consumer path), 46 roles including `andy-policies` with 5 custom roles (admin/author/approver/risk/viewer) and `andy-models` with 4 (admin/curator/reviewer/viewer).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)