### PR TITLE
DataSeeder: bind manifest testUserRole to well-known dev test subject

### DIFF
--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -10,6 +10,17 @@ namespace Andy.Rbac.Api.Data;
 /// </summary>
 public static class DataSeeder
 {
+    /// <summary>
+    /// External identifier of the well-known dev/test user (<c>test@andy.local</c>),
+    /// pinned to the same Guid that andy-auth's <c>DbSeeder.TestUserWellKnownId</c>
+    /// assigns. Pre-binding manifest-declared <c>testUserRole</c> entries to this
+    /// Subject would silently miss real tokens if these constants drifted; both
+    /// repos must be updated together. See rivoli-ai/andy-auth#56 +
+    /// rivoli-ai/andy-rbac#52.
+    /// </summary>
+    public const string TestUserWellKnownExternalId = "00000000-0000-0000-0000-000000000001";
+    public const string TestUserWellKnownEmail = "test@andy.local";
+
     public static async Task SeedAsync(RbacDbContext db, CancellationToken ct = default)
     {
         await SeedActionsAsync(db, ct);
@@ -86,7 +97,112 @@ public static class DataSeeder
             }
         }
 
+        // Persist applications + roles before processing testUserRole bindings —
+        // the latter need the Role rows queryable by code.
         await db.SaveChangesAsync(ct);
+
+        await SeedTestUserRoleBindingsAsync(db, manifests, configuration, logger, ct);
+    }
+
+    /// <summary>
+    /// Manifest-declared <c>testUserRole</c> bindings (#52). For each manifest
+    /// that declares one, ensures the well-known dev test subject
+    /// (<c>test@andy.local</c>, andy-auth's <see cref="TestUserWellKnownExternalId"/>)
+    /// has the named role on this manifest's application. Skipped in Production
+    /// — <c>testUserRole</c> is a dev convenience and never appropriate for prod.
+    /// Idempotent; safe across repeated startups.
+    /// </summary>
+    private static async Task SeedTestUserRoleBindingsAsync(
+        RbacDbContext db,
+        IReadOnlyList<RegistrationManifest> manifests,
+        IConfiguration configuration,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        // Match the same env-var convention used elsewhere in the seeder (andy-auth's
+        // DbSeeder uses the same lookup). Falls back to "Production" — fail-closed.
+        var environment = configuration.GetValue<string>("ASPNETCORE_ENVIRONMENT")
+            ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+            ?? "Production";
+        if (string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase))
+        {
+            // Walk the manifests once to log which bindings were skipped — operators
+            // running a misconfigured Production deployment should see them in logs.
+            foreach (var m in manifests)
+            {
+                if (!string.IsNullOrWhiteSpace(m.Rbac?.TestUserRole))
+                {
+                    logger.LogInformation(
+                        "[manifest] Skipping testUserRole binding ({Role}) on {App} — environment is Production.",
+                        m.Rbac.TestUserRole, m.Rbac.ApplicationCode);
+                }
+            }
+            return;
+        }
+
+        Subject? testSubject = null;
+
+        foreach (var manifest in manifests)
+        {
+            var roleCode = manifest.Rbac?.TestUserRole;
+            if (string.IsNullOrWhiteSpace(roleCode)) continue;
+
+            var app = await db.Applications.FirstOrDefaultAsync(a => a.Code == manifest.Rbac!.ApplicationCode, ct);
+            if (app is null)
+            {
+                logger.LogWarning(
+                    "[manifest] testUserRole '{Role}' declared for application '{App}' but the application row was not found — skipping.",
+                    roleCode, manifest.Rbac!.ApplicationCode);
+                continue;
+            }
+
+            var role = await db.Roles.FirstOrDefaultAsync(r => r.ApplicationId == app.Id && r.Code == roleCode, ct);
+            if (role is null)
+            {
+                logger.LogWarning(
+                    "[manifest] testUserRole '{Role}' declared for '{App}' but no matching role exists in this manifest — skipping.",
+                    roleCode, manifest.Rbac!.ApplicationCode);
+                continue;
+            }
+
+            // Lazily provision the test subject on first need so we don't create
+            // an orphan row for manifests that don't declare a testUserRole.
+            testSubject ??= await GetOrCreateTestSubjectAsync(db, ct);
+
+            if (!await db.SubjectRoles.AnyAsync(sr => sr.SubjectId == testSubject.Id && sr.RoleId == role.Id, ct))
+            {
+                db.SubjectRoles.Add(new SubjectRole
+                {
+                    SubjectId = testSubject.Id,
+                    RoleId = role.Id,
+                    GrantedAt = DateTimeOffset.UtcNow
+                });
+                logger.LogInformation(
+                    "[manifest] Granted role '{Role}' on '{App}' to test user {Email} ({ExternalId}).",
+                    roleCode, manifest.Rbac!.ApplicationCode, TestUserWellKnownEmail, TestUserWellKnownExternalId);
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static async Task<Subject> GetOrCreateTestSubjectAsync(RbacDbContext db, CancellationToken ct)
+    {
+        var subject = await db.Subjects.FirstOrDefaultAsync(s => s.ExternalId == TestUserWellKnownExternalId, ct);
+        if (subject is not null) return subject;
+
+        subject = new Subject
+        {
+            ExternalId = TestUserWellKnownExternalId,
+            Provider = "andy-auth",
+            Type = SubjectType.User,
+            Email = TestUserWellKnownEmail,
+            DisplayName = "Test User",
+            IsActive = true
+        };
+        db.Subjects.Add(subject);
+        await db.SaveChangesAsync(ct);
+        return subject;
     }
 
     private static async Task SeedActionsAsync(RbacDbContext db, CancellationToken ct)

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -2,6 +2,9 @@ using Andy.Rbac.Api.Data;
 using Andy.Rbac.Infrastructure.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Andy.Rbac.Api.Tests.Data;
@@ -281,5 +284,137 @@ public class DataSeederTests
             .FirstOrDefaultAsync(a => a.Code == "andy-docs");
 
         app!.Roles.Should().OnlyContain(r => r.IsSystem);
+    }
+
+    // -- testUserRole binding (#52) ------------------------------------------
+
+    private const string SampleManifestWithTestUserRole = """
+        {
+          "service": {
+            "name": "andy-policies-test",
+            "displayName": "Andy Policies (Test Manifest)",
+            "description": "Fixture",
+            "embeddedProxyPrefix": "/policies"
+          },
+          "rbac": {
+            "applicationCode": "andy-policies-test",
+            "applicationName": "Andy Policies (Test)",
+            "description": "Fixture for DataSeederTests",
+            "resourceTypes": [
+              { "code": "policy", "name": "Policy", "supportsInstances": true }
+            ],
+            "roles": [
+              { "code": "admin", "name": "Administrator", "isSystem": true },
+              { "code": "viewer", "name": "Viewer", "isSystem": true }
+            ],
+            "testUserRole": "admin"
+          }
+        }
+        """;
+
+    private static IConfiguration ConfigurationWithManifest(string manifestPath, string env = "Development")
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = env,
+                ["Registrations:ManifestPaths:0"] = manifestPath,
+            })
+            .Build();
+    }
+
+    private static string WriteTempManifest(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"manifest-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_WithTestUserRole_BindsRoleToWellKnownTestUser()
+    {
+        using var context = CreateContext();
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath);
+            var logger = NullLogger.Instance;
+
+            await DataSeeder.SeedFromManifestsAsync(context, config, logger);
+
+            var subject = await context.Subjects
+                .FirstOrDefaultAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId);
+            subject.Should().NotBeNull();
+            subject!.Email.Should().Be(DataSeeder.TestUserWellKnownEmail);
+
+            var binding = await context.SubjectRoles
+                .Include(sr => sr.Role)
+                .ThenInclude(r => r.Application)
+                .FirstOrDefaultAsync(sr => sr.SubjectId == subject.Id);
+            binding.Should().NotBeNull();
+            binding!.Role.Code.Should().Be("admin");
+            binding.Role.Application!.Code.Should().Be("andy-policies-test");
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_TestUserRole_IsIdempotent()
+    {
+        using var context = CreateContext();
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath);
+            var logger = NullLogger.Instance;
+
+            await DataSeeder.SeedFromManifestsAsync(context, config, logger);
+            await DataSeeder.SeedFromManifestsAsync(context, config, logger);
+
+            (await context.Subjects.CountAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId))
+                .Should().Be(1);
+            (await context.SubjectRoles.CountAsync()).Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_InProduction_SkipsTestUserRoleBinding()
+    {
+        using var context = CreateContext();
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath, env: "Production");
+            var logger = NullLogger.Instance;
+
+            await DataSeeder.SeedFromManifestsAsync(context, config, logger);
+
+            // Application + roles still seed normally; only the testUserRole
+            // binding is skipped.
+            (await context.Applications.AnyAsync(a => a.Code == "andy-policies-test")).Should().BeTrue();
+            (await context.Subjects.AnyAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId))
+                .Should().BeFalse();
+            (await context.SubjectRoles.AnyAsync()).Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public void TestUserWellKnownExternalId_MatchesAndyAuthConstant()
+    {
+        // Locks the constant — andy-auth's DbSeeder.TestUserWellKnownId must
+        // match. If you change one, change both. See rivoli-ai/andy-auth#56.
+        DataSeeder.TestUserWellKnownExternalId.Should().Be("00000000-0000-0000-0000-000000000001");
+        DataSeeder.TestUserWellKnownEmail.Should().Be("test@andy.local");
     }
 }


### PR DESCRIPTION
Closes #52.

## Summary

\`RegistrationManifest.TestUserRole\` was already declared (per the andy-service-template schema), and consumer manifests like \`rivoli-ai/andy-policies/config/registration.json\` populated it (\`testUserRole: \"admin\"\`) — but \`DataSeeder\` ignored the field. End-to-end permission tests in consumer services (rivoli-ai/andy-policies#109) couldn't validate \"user-with-role gets 200 vs user-without gets 403\" without runtime coordination.

This wires the field. For each manifest declaring \`testUserRole\`:
- Locates the role on the manifest's application
- Lazily provisions a \`Subject\` row for \`test@andy.local\` using a well-known \`ExternalId\` (\`00000000-0000-0000-0000-000000000001\`)
- Inserts a \`SubjectRole\` binding if absent

## Cross-repo coupling

The well-known \`ExternalId\` is pinned in \`DataSeeder.TestUserWellKnownExternalId\` public const, **matching rivoli-ai/andy-auth#56's \`DbSeeder.TestUserWellKnownId\`**. Both repos must move together — neither breaks anything in isolation, but only the combined state lets real JWTs from andy-auth match \`Subject.ExternalId\` in andy-rbac. The \`TestUserWellKnownExternalId_MatchesAndyAuthConstant\` test locks the string so drift becomes a CI failure.

## Behaviour

- **Idempotent** — repeated \`SeedFromManifestsAsync\` calls don't duplicate \`Subject\` or \`SubjectRole\` rows.
- **Production guard** — \`testUserRole\` is a dev convenience and is explicitly skipped (with an info log per skipped manifest) when \`ASPNETCORE_ENVIRONMENT == \"Production\"\`. Application + role rows still seed normally; only the user-role binding is gated.
- **Missing-app / missing-role manifests** log a warning and skip rather than throwing.

## Test plan

- [x] **4 new tests, all pass:**
  - \`SeedFromManifestsAsync_WithTestUserRole_BindsRoleToWellKnownTestUser\` — happy path
  - \`SeedFromManifestsAsync_TestUserRole_IsIdempotent\` — second invocation doesn't duplicate
  - \`SeedFromManifestsAsync_InProduction_SkipsTestUserRoleBinding\` — application + roles still land but no Subject/SubjectRole rows
  - \`TestUserWellKnownExternalId_MatchesAndyAuthConstant\` — locks the string
- [ ] **Pre-existing test failures (unrelated to this PR):** 7 of 13 existing \`DataSeederTests\` fail on main with \`NullReferenceException\` — they reference applications (andy-docs, andy-auth, etc.) no longer in the legacy \`SeedApplicationsAsync\` allowlist after the manifest-driven refactor (#43). Verified identical failures on main without this PR's changes. Worth a separate cleanup PR.

## Cross-repo

- **rivoli-ai/andy-auth#56 / PR rivoli-ai/andy-auth#57** — sets the matching well-known \`Id\` on \`test@andy.local\`. Land both for end-to-end correctness.
- **rivoli-ai/andy-policies#109** — E2E permission test, unblocked once both this and andy-auth#57 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)