### PR TITLE
Lazy-provision RBAC Subject rows on first authenticated request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,15 +43,3 @@ ANDY_AUTH_AUDIENCE=urn:andy-rbac-api
 ANDY_RBAC_APPLICATION_CODE=andy-rbac
 ANDY_SETTINGS_APPLICATION_CODE=andy-rbac
 ANDY_FRONTEND_AUTH_CLIENT_ID=andy-rbac-web
-
-# --- Special: andy-auth's Postgres connection ---------------------------------
-# Andy.Rbac.Api seeds its `Subject` table from andy-auth's `AspNetUsers` table
-# directly at startup (see Andy.Rbac.Api/Program.cs). This is unusual — most
-# services would call andy-auth's API instead — and is tracked as a follow-up
-# to refactor.
-#
-# Until that lands, the connection string is config-driven via this env var.
-# Default targets andy-auth's docker-mode Postgres port (7435) on the host.
-# In dotnet mode, override to 5435; in CI/embedded, set to a real DSN or
-# leave blank (the seed wraps the call in try/catch and falls back).
-ANDY_AUTH_DB_CONNECTION=Host=host.docker.internal;Port=7435;Database=andy_auth_dev;Username=postgres;Password=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - Auth__Authority=${ANDY_AUTH_AUTHORITY:-https://host.docker.internal:7001}
       - Auth__Audience=${ANDY_AUTH_AUDIENCE:-urn:andy-rbac-api}
       - AndyAuth__Authority=${ANDY_AUTH_AUTHORITY:-https://host.docker.internal:7001}
-      - AndyAuth__DbConnectionString=${ANDY_AUTH_DB_CONNECTION:-Host=host.docker.internal;Port=7435;Database=andy_auth_dev;Username=postgres;Password=postgres}
       - Mcp__ServerUrl=${ANDY_RBAC_API_BASE_URL:-https://host.docker.internal:7003}
       - Cors__Origins__0=https://localhost:5180
       - Cors__Origins__1=http://localhost:5180

--- a/src/Andy.Rbac.Api/Middleware/EnsureSubjectMiddleware.cs
+++ b/src/Andy.Rbac.Api/Middleware/EnsureSubjectMiddleware.cs
@@ -1,0 +1,70 @@
+using System.Security.Claims;
+using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Rbac.Api.Middleware;
+
+/// <summary>
+/// Lazily provisions a <see cref="Subject"/> row for the authenticated user on
+/// first request. Replaces the previous startup-time bulk seed that opened a
+/// direct Postgres connection to andy-auth's database.
+///
+/// Skips:
+///   - Anonymous requests.
+///   - Service-account tokens (client_credentials grant): andy-auth issues
+///     these with sub=client_id and no email claim. We use the absence of
+///     the email claim as the signal that this isn't a human user.
+///
+/// On a hit, refreshes <see cref="Subject.LastSeenAt"/> at most once per
+/// 5 minutes per subject — bounded write load on otherwise idle DB.
+/// </summary>
+public class EnsureSubjectMiddleware
+{
+    private static readonly TimeSpan LastSeenRefreshInterval = TimeSpan.FromMinutes(5);
+    private readonly RequestDelegate _next;
+
+    public EnsureSubjectMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext context, RbacDbContext db, ILogger<EnsureSubjectMiddleware> logger)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var sub = context.User.FindFirst("sub")?.Value
+                ?? context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var email = context.User.FindFirst("email")?.Value
+                ?? context.User.FindFirst(ClaimTypes.Email)?.Value;
+
+            if (!string.IsNullOrEmpty(sub) && !string.IsNullOrEmpty(email))
+            {
+                var existing = await db.Subjects.FirstOrDefaultAsync(s => s.ExternalId == sub);
+                if (existing is null)
+                {
+                    var name = context.User.FindFirst("name")?.Value
+                        ?? context.User.FindFirst("preferred_username")?.Value
+                        ?? email;
+                    db.Subjects.Add(new Subject
+                    {
+                        ExternalId = sub,
+                        Provider = "andy-auth",
+                        Type = SubjectType.User,
+                        Email = email,
+                        DisplayName = name,
+                        IsActive = true,
+                        LastSeenAt = DateTimeOffset.UtcNow,
+                    });
+                    await db.SaveChangesAsync();
+                    logger.LogInformation("Auto-provisioned Subject for {Email} ({Sub}).", email, sub);
+                }
+                else if (existing.LastSeenAt is null
+                    || DateTimeOffset.UtcNow - existing.LastSeenAt.Value > LastSeenRefreshInterval)
+                {
+                    existing.LastSeenAt = DateTimeOffset.UtcNow;
+                    await db.SaveChangesAsync();
+                }
+            }
+        }
+
+        await _next(context);
+    }
+}

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -1,5 +1,6 @@
 using Andy.Rbac.Api.Data;
 using Andy.Rbac.Api.Mcp;
+using Andy.Rbac.Api.Middleware;
 using Andy.Rbac.Api.Services;
 using Andy.Rbac.Infrastructure.Data;
 using Andy.Rbac.Infrastructure.Repositories;
@@ -178,6 +179,7 @@ app.UseHttpsRedirection();
 app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<EnsureSubjectMiddleware>();
 
 app.MapControllers();
 app.MapGrpcService<RbacGrpcService>();
@@ -292,41 +294,10 @@ using (var scope = app.Services.CreateScope())
     // Seed super-admin permissions for all resource types
     await DataSeeder.SeedSuperAdminPermissionsAsync(db);
 
-    // Seed dev users with super-admin role (development only).
-    // Reads andy-auth's Postgres directly — sourced from .env / compose
-    // (ANDY_AUTH_DB_CONNECTION → AndyAuth__DbConnectionString). When the
-    // env var is missing or the DB unreachable, falls back to a single
-    // hardcoded test subject. The direct-DB read is a known wart and
-    // tracked as a follow-up to refactor onto the andy-auth API.
-    if (app.Environment.IsDevelopment())
-    {
-        var authDbConn = app.Configuration["AndyAuth:DbConnectionString"];
-        if (string.IsNullOrWhiteSpace(authDbConn))
-        {
-            app.Logger.LogWarning("AndyAuth:DbConnectionString not set; skipping user seeding from Andy.Auth DB.");
-            await DataSeeder.SeedTestSubjectAsync(db, "45abdfa0-da00-4bff-9226-9c91fcda15b1", "test@andy.local");
-        }
-        else
-        {
-            try
-            {
-                using var authConn = new Npgsql.NpgsqlConnection(authDbConn);
-                await authConn.OpenAsync();
-                using var cmd = new Npgsql.NpgsqlCommand(
-                    "SELECT \"Id\", \"Email\" FROM \"AspNetUsers\" WHERE \"IsActive\" = true", authConn);
-                using var reader = await cmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
-                {
-                    await DataSeeder.SeedTestSubjectAsync(db, reader.GetString(0), reader.GetString(1));
-                }
-            }
-            catch (Exception ex)
-            {
-                app.Logger.LogWarning(ex, "Could not seed from Andy.Auth DB, using fallback");
-                await DataSeeder.SeedTestSubjectAsync(db, "45abdfa0-da00-4bff-9226-9c91fcda15b1", "test@andy.local");
-            }
-        }
-    }
+    // Real users get their Subject row created lazily on first authenticated
+    // request — see Andy.Rbac.Api.Middleware.EnsureSubjectMiddleware. The
+    // well-known dev test subject (test@andy.local) is upserted by
+    // SeedFromManifestsAsync above when binding the manifest's testUserRole.
 }
 
 app.Run();

--- a/src/Andy.Rbac.Api/appsettings.Development.json
+++ b/src/Andy.Rbac.Api/appsettings.Development.json
@@ -8,8 +8,7 @@
     "Audience": ""
   },
   "AndyAuth": {
-    "Authority": "",
-    "DbConnectionString": ""
+    "Authority": ""
   },
   "Mcp": {
     "ServerUrl": "",

--- a/src/Andy.Rbac.Api/appsettings.json
+++ b/src/Andy.Rbac.Api/appsettings.json
@@ -11,8 +11,7 @@
     "Audience": ""
   },
   "AndyAuth": {
-    "Authority": "",
-    "DbConnectionString": ""
+    "Authority": ""
   },
   "Mcp": {
     "ServerUrl": "",


### PR DESCRIPTION
## Summary

Removes the startup-time bulk seed that opened a direct Postgres connection to andy-auth's `AspNetUsers` table. That cross-service coupling was brittle even after Phase 3 made the connection string config-driven — rbac was still depending on a sibling service's DB internals at boot.

Replaces it with `EnsureSubjectMiddleware` which runs after authentication and upserts a `Subject` row for the current user the first time they hit any endpoint.

## What changed

- **Add** `Andy.Rbac.Api/Middleware/EnsureSubjectMiddleware.cs`. Reads `sub` / `email` / `name` claims from the authenticated principal and upserts a `Subject` row keyed by ExternalId. Skips:
  - Anonymous requests.
  - Service-account tokens — andy-auth issues these with `sub`=client_id and no `email` claim. We use the missing email as the signal.
- **Wire** it in `Program.cs` after `UseAuthentication` / `UseAuthorization`.
- **Remove** the entire startup-time `if (Development) { try { read andy-auth DB } catch { fallback } }` block. The well-known dev test subject (`test@andy.local`) is still upserted by `SeedFromManifestsAsync` when binding the manifest's `testUserRole` — no behavior change there.
- **Strip** the now-unused `AndyAuth__DbConnectionString` / `ANDY_AUTH_DB_CONNECTION` config from `appsettings{,.Development}.json`, `docker-compose.yml`, and `.env.example`.

`LastSeenAt` is refreshed at most once per 5 minutes per subject — bounded write load on otherwise idle DBs.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` reports 351 passing / 19 pre-existing failures (same baseline as main, no regressions).
- [ ] End-to-end: authenticate with a fresh user against a running rbac → first request creates a Subject row, subsequent requests refresh `LastSeenAt`.
- [ ] End-to-end: authenticate with a service-account (client_credentials) token → no Subject created.

## Notes

This was the parked follow-up from PR #56. Closes the cross-service coupling at startup. The Phase 3 memory note about "refactor onto andy-auth API" turned out to be unnecessary — there's no need to call andy-auth at all if we just provision lazily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)