### PR TITLE
Require explicit Rbac:AllowTestUserSeed flag for testUserRole seeding

### DIFF
--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -119,22 +119,32 @@ public static class DataSeeder
         ILogger logger,
         CancellationToken ct)
     {
-        // Match the same env-var convention used elsewhere in the seeder (andy-auth's
-        // DbSeeder uses the same lookup). Falls back to "Production" — fail-closed.
+        // Defense-in-depth gate (issue #49): the binding requires BOTH a
+        // non-Production environment AND an explicit `Rbac:AllowTestUserSeed`
+        // opt-in. A leaked `ASPNETCORE_ENVIRONMENT=Development` to a real
+        // deployment alone is no longer enough to activate the well-known
+        // backdoor subject — the operator would also have to flip the
+        // explicit flag.
         var environment = configuration.GetValue<string>("ASPNETCORE_ENVIRONMENT")
             ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
             ?? "Production";
-        if (string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase))
+        var allowTestUserSeed = configuration.GetValue<bool>("Rbac:AllowTestUserSeed");
+        var isProduction = string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
+
+        if (isProduction || !allowTestUserSeed)
         {
             // Walk the manifests once to log which bindings were skipped — operators
-            // running a misconfigured Production deployment should see them in logs.
+            // running a misconfigured deployment should see them in logs.
+            var reason = isProduction
+                ? "environment is Production"
+                : "Rbac:AllowTestUserSeed is not set";
             foreach (var m in manifests)
             {
                 if (!string.IsNullOrWhiteSpace(m.Rbac?.TestUserRole))
                 {
                     logger.LogInformation(
-                        "[manifest] Skipping testUserRole binding ({Role}) on {App} — environment is Production.",
-                        m.Rbac.TestUserRole, m.Rbac.ApplicationCode);
+                        "[manifest] Skipping testUserRole binding ({Role}) on {App} — {Reason}.",
+                        m.Rbac.TestUserRole, m.Rbac.ApplicationCode, reason);
                 }
             }
             return;

--- a/src/Andy.Rbac.Api/appsettings.Development.json
+++ b/src/Andy.Rbac.Api/appsettings.Development.json
@@ -14,6 +14,10 @@
     "ServerUrl": "",
     "McpPath": "/mcp"
   },
+  "Rbac": {
+    "//": "Explicit opt-in (#49). Combined with ASPNETCORE_ENVIRONMENT != Production, this allows binding the well-known dev test subject to per-manifest testUserRole. Never set this in non-dev appsettings.",
+    "AllowTestUserSeed": true
+  },
   "Cors": {
     "Origins": [
       "http://localhost:3000",

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -312,13 +312,17 @@ public class DataSeederTests
         }
         """;
 
-    private static IConfiguration ConfigurationWithManifest(string manifestPath, string env = "Development")
+    private static IConfiguration ConfigurationWithManifest(
+        string manifestPath,
+        string env = "Development",
+        bool allowTestUserSeed = true)
     {
         return new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ASPNETCORE_ENVIRONMENT"] = env,
                 ["Registrations:ManifestPaths:0"] = manifestPath,
+                ["Rbac:AllowTestUserSeed"] = allowTestUserSeed ? "true" : "false",
             })
             .Build();
     }
@@ -398,6 +402,32 @@ public class DataSeederTests
 
             // Application + roles still seed normally; only the testUserRole
             // binding is skipped.
+            (await context.Applications.AnyAsync(a => a.Code == "andy-policies-test")).Should().BeTrue();
+            (await context.Subjects.AnyAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId))
+                .Should().BeFalse();
+            (await context.SubjectRoles.AnyAsync()).Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_WithoutAllowTestUserSeedFlag_SkipsBinding()
+    {
+        // Issue #49: even in Development, the binding requires an explicit
+        // Rbac:AllowTestUserSeed=true opt-in. A leaked Development env alone
+        // is not enough to activate the well-known test subject.
+        using var context = CreateContext();
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath, env: "Development", allowTestUserSeed: false);
+            var logger = NullLogger.Instance;
+
+            await DataSeeder.SeedFromManifestsAsync(context, config, logger);
+
             (await context.Applications.AnyAsync(a => a.Code == "andy-policies-test")).Should().BeTrue();
             (await context.Subjects.AnyAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId))
                 .Should().BeFalse();


### PR DESCRIPTION
Closes #49.

## Summary

Defense-in-depth gate against the well-known test subject becoming a backdoor if `ASPNETCORE_ENVIRONMENT=Development` leaks to a real deployment. The seed now requires **both**:

- non-Production environment (existing gate), AND
- `Rbac:AllowTestUserSeed=true` in configuration (new gate).

Either gate failing causes the seed to log the skipped bindings and return — no Subject row created, no SubjectRole rows created.

The flag is set in `appsettings.Development.json` so local dev is unchanged. The companion `appsettings.json` (used by all other environments) does not set it, so the flag is fail-closed by default.

## Context

PR #57 already removed the `Port=5435` hardcoded DB connection that was the other half of the original #49. That change made cross-service startup coupling go away; this PR tightens the residual concern (well-known subject backdoor in dev-leaked-to-prod) by adding an opt-in flag.

## What changed

- `src/Andy.Rbac.Api/Data/DataSeeder.cs` — `SeedTestUserRoleBindingsAsync` now skips when `Rbac:AllowTestUserSeed` is false, in addition to skipping in Production.
- `src/Andy.Rbac.Api/appsettings.Development.json` — sets `Rbac:AllowTestUserSeed=true`. `appsettings.json` is unchanged.
- `tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs` — `ConfigurationWithManifest` helper sets the flag by default (mirrors dev appsettings); added `allowTestUserSeed` parameter so the gate is testable. New `SeedFromManifestsAsync_WithoutAllowTestUserSeedFlag_SkipsBinding` test asserts the flag-off path even in Development.

## Test plan

- [x] `dotnet build` clean.
- [x] `dotnet test` reports 352 passing / 19 pre-existing failures (baseline + the new flag-gate test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)