### PR TITLE
[CRITICAL] Restore auth on every controller; drop caller-supplied Groups

### DIFF
--- a/src/Andy.Rbac.Api/Controllers/ApplicationsController.cs
+++ b/src/Andy.Rbac.Api/Controllers/ApplicationsController.cs
@@ -9,8 +9,7 @@ namespace Andy.Rbac.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-// Note: Auth temporarily disabled for development/testing
-// [Authorize]
+[Authorize]
 public class ApplicationsController : ControllerBase
 {
     private readonly IApplicationService _applicationService;
@@ -24,7 +23,6 @@ public class ApplicationsController : ControllerBase
     /// Gets all registered applications.
     /// </summary>
     [HttpGet]
-    [AllowAnonymous] // Allow listing for testing
     [ProducesResponseType(typeof(ApplicationResult), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetApplications(CancellationToken ct)
     {
@@ -36,7 +34,6 @@ public class ApplicationsController : ControllerBase
     /// Gets an application by ID with full details.
     /// </summary>
     [HttpGet("{id:guid}")]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(ApplicationDetail), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetApplication(Guid id, CancellationToken ct)
@@ -52,7 +49,6 @@ public class ApplicationsController : ControllerBase
     /// Gets an application by code.
     /// </summary>
     [HttpGet("by-code/{code}")]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(ApplicationDetail), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetApplicationByCode(string code, CancellationToken ct)

--- a/src/Andy.Rbac.Api/Controllers/CheckController.cs
+++ b/src/Andy.Rbac.Api/Controllers/CheckController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Andy.Rbac.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,8 +10,7 @@ namespace Andy.Rbac.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-// Note: Auth temporarily disabled for development/testing
-// [Authorize]
+[Authorize]
 public class CheckController : ControllerBase
 {
     private readonly IPermissionEvaluator _evaluator;
@@ -23,8 +23,27 @@ public class CheckController : ControllerBase
     }
 
     /// <summary>
+    /// Group memberships are sourced from the validated JWT (issue #45) when
+    /// the request is checking the caller's own subject. For checks targeting
+    /// other subjects, group claims from the caller's token do not apply —
+    /// only directly-granted permissions are considered. Stored group
+    /// memberships per subject are tracked separately (out of scope here).
+    /// </summary>
+    private List<string>? GroupsForSubject(string subjectExternalId)
+    {
+        var callerSub = User.FindFirst("sub")?.Value
+            ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (callerSub is null || !string.Equals(callerSub, subjectExternalId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var groups = User.FindAll("groups").Select(c => c.Value).ToList();
+        return groups.Count > 0 ? groups : null;
+    }
+
+    /// <summary>
     /// Checks if a subject has a specific permission.
-    /// Groups are optional and represent group memberships from the token.
     /// </summary>
     [HttpPost]
     [ProducesResponseType(typeof(CheckPermissionResponse), StatusCodes.Status200OK)]
@@ -33,7 +52,7 @@ public class CheckController : ControllerBase
         var result = await _evaluator.CheckPermissionAsync(
             request.SubjectId,
             request.Permission,
-            request.Groups,
+            GroupsForSubject(request.SubjectId),
             request.ResourceInstanceId,
             ct);
 
@@ -46,7 +65,6 @@ public class CheckController : ControllerBase
 
     /// <summary>
     /// Checks if a subject has any of the specified permissions.
-    /// Groups are optional and represent group memberships from the token.
     /// </summary>
     [HttpPost("any")]
     [ProducesResponseType(typeof(CheckPermissionResponse), StatusCodes.Status200OK)]
@@ -55,7 +73,7 @@ public class CheckController : ControllerBase
         var result = await _evaluator.CheckAnyPermissionAsync(
             request.SubjectId,
             request.Permissions,
-            request.Groups,
+            GroupsForSubject(request.SubjectId),
             request.ResourceInstanceId,
             ct);
 
@@ -68,35 +86,29 @@ public class CheckController : ControllerBase
 
     /// <summary>
     /// Gets all permissions for a subject.
-    /// Groups query parameter can be comma-separated list of group codes.
     /// </summary>
     [HttpGet("permissions/{subjectId}")]
     [ProducesResponseType(typeof(GetPermissionsResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPermissions(
         string subjectId,
-        [FromQuery] string? groups,
         [FromQuery] string? applicationCode,
         CancellationToken ct)
     {
-        var groupList = string.IsNullOrEmpty(groups) ? null : groups.Split(',').Select(g => g.Trim()).ToList();
-        var permissions = await _evaluator.GetPermissionsAsync(subjectId, groupList, applicationCode, ct);
+        var permissions = await _evaluator.GetPermissionsAsync(subjectId, GroupsForSubject(subjectId), applicationCode, ct);
         return Ok(new GetPermissionsResponse { Permissions = permissions.ToList() });
     }
 
     /// <summary>
     /// Gets all roles for a subject.
-    /// Groups query parameter can be comma-separated list of group codes.
     /// </summary>
     [HttpGet("roles/{subjectId}")]
     [ProducesResponseType(typeof(GetRolesResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetRoles(
         string subjectId,
-        [FromQuery] string? groups,
         [FromQuery] string? applicationCode,
         CancellationToken ct)
     {
-        var groupList = string.IsNullOrEmpty(groups) ? null : groups.Split(',').Select(g => g.Trim()).ToList();
-        var roles = await _evaluator.GetRolesAsync(subjectId, groupList, applicationCode, ct);
+        var roles = await _evaluator.GetRolesAsync(subjectId, GroupsForSubject(subjectId), applicationCode, ct);
         return Ok(new GetRolesResponse { Roles = roles.ToList() });
     }
 }
@@ -106,12 +118,10 @@ public class CheckController : ControllerBase
 /// </summary>
 /// <param name="SubjectId">External ID of the subject (user).</param>
 /// <param name="Permission">Permission code in format "app:resource:action".</param>
-/// <param name="Groups">Optional group codes from token claims. Permissions are checked for subject + all groups.</param>
 /// <param name="ResourceInstanceId">Optional resource instance ID for instance-level checks.</param>
 public record CheckPermissionRequest(
     string SubjectId,
     string Permission,
-    List<string>? Groups = null,
     string? ResourceInstanceId = null);
 
 /// <summary>
@@ -120,7 +130,6 @@ public record CheckPermissionRequest(
 public record CheckAnyPermissionRequest(
     string SubjectId,
     List<string> Permissions,
-    List<string>? Groups = null,
     string? ResourceInstanceId = null);
 
 public record CheckPermissionResponse { public bool Allowed { get; init; } public string? Reason { get; init; } }

--- a/src/Andy.Rbac.Api/Controllers/RolesController.cs
+++ b/src/Andy.Rbac.Api/Controllers/RolesController.cs
@@ -9,8 +9,7 @@ namespace Andy.Rbac.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-// Note: Auth temporarily disabled for development/testing
-// [Authorize]
+[Authorize]
 public class RolesController : ControllerBase
 {
     private readonly IRoleService _roleService;
@@ -24,7 +23,6 @@ public class RolesController : ControllerBase
     /// Gets all roles, optionally filtered by application.
     /// </summary>
     [HttpGet]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(List<RoleDetail>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetRoles([FromQuery] string? applicationCode, CancellationToken ct)
     {
@@ -36,7 +34,6 @@ public class RolesController : ControllerBase
     /// Gets a role by ID.
     /// </summary>
     [HttpGet("{id:guid}")]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(RoleDetail), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetRole(Guid id, CancellationToken ct)
@@ -52,7 +49,6 @@ public class RolesController : ControllerBase
     /// Gets a role by code.
     /// </summary>
     [HttpGet("by-code/{code}")]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(RoleDetail), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetRoleByCode(string code, [FromQuery] string? applicationCode, CancellationToken ct)

--- a/src/Andy.Rbac.Api/Controllers/SubjectsController.cs
+++ b/src/Andy.Rbac.Api/Controllers/SubjectsController.cs
@@ -11,8 +11,7 @@ namespace Andy.Rbac.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-// Note: Auth temporarily disabled for development/testing
-// [Authorize]
+[Authorize]
 public class SubjectsController : ControllerBase
 {
     private readonly RbacDbContext _db;

--- a/src/Andy.Rbac.Api/Controllers/TeamsController.cs
+++ b/src/Andy.Rbac.Api/Controllers/TeamsController.cs
@@ -11,8 +11,7 @@ namespace Andy.Rbac.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-// Note: Auth temporarily disabled for development/testing
-// [Authorize]
+[Authorize]
 public class TeamsController : ControllerBase
 {
     private readonly RbacDbContext _db;

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -181,8 +181,8 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<EnsureSubjectMiddleware>();
 
-app.MapControllers();
-app.MapGrpcService<RbacGrpcService>();
+app.MapControllers().RequireAuthorization();
+app.MapGrpcService<RbacGrpcService>().RequireAuthorization();
 
 // Map MCP Server endpoint at /mcp with permissive CORS for MCP clients
 // Require authorization so clients (e.g., Claude Desktop) receive an OAuth challenge

--- a/tests/Andy.Rbac.Api.Tests/Integration/RbacWebApplicationFactory.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/RbacWebApplicationFactory.cs
@@ -1,6 +1,8 @@
 using Andy.Rbac.Infrastructure.Data;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -44,6 +46,16 @@ public class RbacWebApplicationFactory : WebApplicationFactory<Program>
 
             // Seed test data
             TestDbContextFactory.SeedTestDataAsync(db).GetAwaiter().GetResult();
+        });
+
+        // Replace the auth scheme with a test handler that always succeeds
+        // as a fixed in-memory test user. Runs in ConfigureTestServices so
+        // it overrides Program.cs's Bearer/MCP scheme registration.
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(TestAuthHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                    TestAuthHandler.SchemeName, _ => { });
         });
 
         builder.UseEnvironment("Testing");

--- a/tests/Andy.Rbac.Api.Tests/Integration/TestAuthHandler.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/TestAuthHandler.cs
@@ -1,0 +1,45 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Rbac.Api.Tests.Integration;
+
+/// <summary>
+/// Test authentication handler — every request authenticates as a fixed
+/// in-memory test user. The integration suite exercises domain logic, not
+/// auth flows; the per-test auth state can be customized via headers if a
+/// test ever needs to.
+/// </summary>
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "Test";
+    public const string TestSub = "test-subject";
+    public const string TestEmail = "test@example.com";
+    public const string TestName = "Test User";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim("sub", TestSub),
+            new Claim(ClaimTypes.NameIdentifier, TestSub),
+            new Claim("email", TestEmail),
+            new Claim(ClaimTypes.Email, TestEmail),
+            new Claim("name", TestName),
+        };
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}


### PR DESCRIPTION
Closes #44, #45.

## #44 — Authentication disabled on every endpoint

`[Authorize]` was commented out on every controller; `MapControllers` and `MapGrpcService` weren't `.RequireAuthorization()`-gated; only `/mcp` required auth. Any unauthenticated caller could grant `super-admin`, delete applications, or provision subjects.

**Fix:**
- Restore `[Authorize]` on `CheckController`, `RolesController`, `SubjectsController`, `TeamsController`, `ApplicationsController`.
- `.RequireAuthorization()` on `MapControllers()` and `MapGrpcService<RbacGrpcService>()`.
- Remove every per-method `[AllowAnonymous]` workaround that was bypassing the disabled top-level gate.

`/health`, `/.well-known/*`, and `DynamicClientRegistrationController` remain explicitly anonymous — those are designed to be.

The issue's secondary suggestion ("split read-only checks from mutating admin endpoints + distinct `rbac:admin` scope") is **left as a follow-up**. Minimum fix: auth required everywhere.

## #45 — Caller-supplied Groups field trusted as if from JWT

`CheckPermissionRequest.Groups` (and the GET endpoints' `?groups=...` query) were read from the caller and flowed into `GetRoleIdsForGroupsAsync`/`ExternalGroupMappings` with no verification. Any caller could claim arbitrary groups and collect their mapped permissions.

**Fix:**
- Drop `Groups` from `CheckPermissionRequest` and `CheckAnyPermissionRequest`.
- Drop `groups` query parameters from `/api/check/permissions/{id}` and `/api/check/roles/{id}`.
- New `CheckController.GroupsForSubject` helper: returns groups from `HttpContext.User` claims **only when the request targets the caller's own subject**. For admin/service checks against foreign subjects, returns `null` — only directly-granted permissions count.

This is intentionally narrow: foreign-subject group lookup needs either stored group memberships (not yet modeled) or a signed assertion from andy-auth (not yet implemented). Refusing to trust caller-supplied groups for foreign subjects is the right default until one of those paths lands.

## Tests

Restoring auth would have failed every integration test (no JWT in test requests). Added `TestAuthHandler` (a stub `AuthenticationHandler<AuthenticationSchemeOptions>` that always succeeds as a fixed test user) and wired it via `RbacWebApplicationFactory.ConfigureTestServices` so the host's auth scheme is replaced for tests only.

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` reports 352 passing / 19 pre-existing failures (same baseline as main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)