### PR TITLE
[CRITICAL] Fix inverted role-inheritance query; add cycle detection

### DIFF
--- a/src/Andy.Rbac.Api/Services/RoleService.cs
+++ b/src/Andy.Rbac.Api/Services/RoleService.cs
@@ -106,6 +106,14 @@ public class RoleService : IRoleService
             if (parent == null)
                 throw new InvalidOperationException($"Parent role '{request.ParentRoleCode}' not found");
             parentRoleId = parent.Id;
+
+            // Defense-in-depth (issue #46): walk the proposed parent chain to
+            // confirm no cycle exists in the graph we'd be inserting into.
+            // For a brand-new Create the new role can't have any incoming
+            // ParentRoleId references, so a cycle through it is impossible —
+            // but the helper is reused on Update if/when that endpoint is added,
+            // and a corrupt parent chain should be rejected loudly anyway.
+            await EnsureParentChainIsAcyclicAsync(parent.Id, ct);
         }
 
         var role = new Role
@@ -132,6 +140,37 @@ public class RoleService : IRoleService
             request.ParentRoleCode,
             role.IsSystem,
             []));
+    }
+
+    /// <summary>
+    /// Walks the parent chain starting from <paramref name="startId"/>, throwing
+    /// <see cref="InvalidOperationException"/> if any role is encountered twice
+    /// (i.e. a cycle exists). Bounded depth defends against pathological cases.
+    /// </summary>
+    private async Task EnsureParentChainIsAcyclicAsync(Guid startId, CancellationToken ct)
+    {
+        const int maxDepth = 32;
+        var visited = new HashSet<Guid>();
+        Guid? current = startId;
+        for (int d = 0; d < maxDepth && current.HasValue; d++)
+        {
+            if (!visited.Add(current.Value))
+            {
+                throw new InvalidOperationException(
+                    $"Role parent chain contains a cycle at role {current.Value}.");
+            }
+
+            current = await _db.Roles
+                .Where(r => r.Id == current.Value)
+                .Select(r => r.ParentRoleId)
+                .FirstOrDefaultAsync(ct);
+        }
+
+        if (current.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Role parent chain exceeds the maximum depth of {maxDepth}.");
+        }
     }
 
     public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)

--- a/src/Andy.Rbac.Infrastructure/Repositories/PermissionRepository.cs
+++ b/src/Andy.Rbac.Infrastructure/Repositories/PermissionRepository.cs
@@ -13,6 +13,35 @@ public class PermissionRepository : IPermissionRepository
         _db = db;
     }
 
+    /// <summary>
+    /// Expand a starting set of role IDs to include all of their ancestors
+    /// (parents, grandparents, ...) walking the <c>ParentRoleId</c> chain.
+    /// Cycle-safe — the loop terminates as soon as a frontier yields no new
+    /// IDs. Bounded depth defends against accidentally-deep hierarchies.
+    /// </summary>
+    private async Task<HashSet<Guid>> ExpandToAncestorsAsync(
+        IEnumerable<Guid> roleIds,
+        CancellationToken ct)
+    {
+        const int maxDepth = 32;
+        var closure = new HashSet<Guid>(roleIds);
+        var frontier = new HashSet<Guid>(closure);
+        for (int d = 0; d < maxDepth && frontier.Count > 0; d++)
+        {
+            var parents = await _db.Roles
+                .Where(r => frontier.Contains(r.Id) && r.ParentRoleId != null)
+                .Select(r => r.ParentRoleId!.Value)
+                .Distinct()
+                .ToListAsync(ct);
+
+            var newOnes = parents.Where(p => !closure.Contains(p)).ToList();
+            if (newOnes.Count == 0) break;
+            foreach (var p in newOnes) closure.Add(p);
+            frontier = new HashSet<Guid>(newOnes);
+        }
+        return closure;
+    }
+
     public async Task<IReadOnlyList<string>> GetPermissionsForSubjectAsync(
         Guid subjectId,
         string? applicationCode = null,
@@ -31,11 +60,14 @@ public class PermissionRepository : IPermissionRepository
         if (!roleIds.Any())
             return [];
 
-        // Get permissions from these roles (including parent roles up to 3 levels)
+        // Inheritance: a subject with role R holds the permissions of R
+        // and of every ancestor of R (via ParentRoleId). Expand the assigned
+        // set to include all ancestors, then match RolePermissions against
+        // that expanded set.
+        var effectiveRoleIds = await ExpandToAncestorsAsync(roleIds, ct);
+
         var query = _db.RolePermissions
-            .Where(rp => roleIds.Contains(rp.RoleId) ||
-                        (rp.Role.ParentRoleId != null && roleIds.Contains(rp.Role.ParentRoleId.Value)) ||
-                        (rp.Role.ParentRole != null && rp.Role.ParentRole.ParentRoleId != null && roleIds.Contains(rp.Role.ParentRole.ParentRoleId.Value)))
+            .Where(rp => effectiveRoleIds.Contains(rp.RoleId))
             .Include(rp => rp.Permission)
             .ThenInclude(p => p.ResourceType)
             .ThenInclude(rt => rt.Application)
@@ -112,11 +144,10 @@ public class PermissionRepository : IPermissionRepository
         }
         else
         {
-            // Check role-based permissions (including parent roles)
+            // Inherit ancestors (see ExpandToAncestorsAsync).
+            var effectiveRoleIds = await ExpandToAncestorsAsync(roleIds, ct);
             var hasRolePermission = await _db.RolePermissions
-                .Where(rp => roleIds.Contains(rp.RoleId) ||
-                            (rp.Role.ParentRoleId != null && roleIds.Contains(rp.Role.ParentRoleId.Value)) ||
-                            (rp.Role.ParentRole != null && rp.Role.ParentRole.ParentRoleId != null && roleIds.Contains(rp.Role.ParentRole.ParentRoleId.Value)))
+                .Where(rp => effectiveRoleIds.Contains(rp.RoleId))
                 .AnyAsync(rp =>
                     rp.Permission.ResourceType.Application != null &&
                     rp.Permission.ResourceType.Application.Code == appCode &&
@@ -183,10 +214,10 @@ public class PermissionRepository : IPermissionRepository
         if (!roleIdList.Any())
             return [];
 
+        var effectiveRoleIds = await ExpandToAncestorsAsync(roleIdList, ct);
+
         var query = _db.RolePermissions
-            .Where(rp => roleIdList.Contains(rp.RoleId) ||
-                        (rp.Role.ParentRoleId != null && roleIdList.Contains(rp.Role.ParentRoleId.Value)) ||
-                        (rp.Role.ParentRole != null && rp.Role.ParentRole.ParentRoleId != null && roleIdList.Contains(rp.Role.ParentRole.ParentRoleId.Value)))
+            .Where(rp => effectiveRoleIds.Contains(rp.RoleId))
             .Include(rp => rp.Permission)
             .ThenInclude(p => p.ResourceType)
             .ThenInclude(rt => rt.Application)
@@ -225,11 +256,10 @@ public class PermissionRepository : IPermissionRepository
         var resourceCode = parts[1];
         var actionCode = parts[2];
 
-        // Check role-based permissions (including parent roles)
+        var effectiveRoleIds = await ExpandToAncestorsAsync(roleIdList, ct);
+
         return await _db.RolePermissions
-            .Where(rp => roleIdList.Contains(rp.RoleId) ||
-                        (rp.Role.ParentRoleId != null && roleIdList.Contains(rp.Role.ParentRoleId.Value)) ||
-                        (rp.Role.ParentRole != null && rp.Role.ParentRole.ParentRoleId != null && roleIdList.Contains(rp.Role.ParentRole.ParentRoleId.Value)))
+            .Where(rp => effectiveRoleIds.Contains(rp.RoleId))
             .AnyAsync(rp =>
                 rp.Permission.ResourceType.Application != null &&
                 rp.Permission.ResourceType.Application.Code == appCode &&

--- a/tests/Andy.Rbac.Api.Tests/Repositories/PermissionRepositoryInheritanceTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Repositories/PermissionRepositoryInheritanceTests.cs
@@ -1,0 +1,174 @@
+using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Infrastructure.Repositories;
+using Andy.Rbac.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Rbac.Api.Tests.Repositories;
+
+/// <summary>
+/// Issue #46 — verifies role-permission inheritance walks the parent chain in
+/// the correct direction (child inherits from parent) and is cycle-safe.
+/// </summary>
+public class PermissionRepositoryInheritanceTests
+{
+    private static (RbacDbContext db, Subject subject, Role parent, Role child, string permissionCode) BuildHierarchy()
+    {
+        var db = TestDbContextFactory.Create();
+
+        var app = new Application { Id = Guid.NewGuid(), Code = "app", Name = "App" };
+        db.Applications.Add(app);
+
+        var resourceType = new ResourceType
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = app.Id,
+            Code = "thing",
+            Name = "Thing",
+        };
+        db.ResourceTypes.Add(resourceType);
+
+        var action = new Andy.Rbac.Models.Action { Id = Guid.NewGuid(), Code = "read", Name = "Read" };
+        db.Actions.Add(action);
+
+        var permission = new Permission
+        {
+            Id = Guid.NewGuid(),
+            ResourceTypeId = resourceType.Id,
+            ActionId = action.Id,
+        };
+        db.Permissions.Add(permission);
+
+        var parent = new Role
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = app.Id,
+            Code = "parent",
+            Name = "Parent",
+        };
+        var child = new Role
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = app.Id,
+            Code = "child",
+            Name = "Child",
+            ParentRoleId = parent.Id,
+        };
+        db.Roles.AddRange(parent, child);
+
+        // Parent role holds the permission. Child should inherit it.
+        db.RolePermissions.Add(new RolePermission { RoleId = parent.Id, PermissionId = permission.Id });
+
+        var subject = new Subject
+        {
+            Id = Guid.NewGuid(),
+            ExternalId = "test-sub",
+            Provider = "andy-auth",
+            Email = "test@example.com",
+        };
+        db.Subjects.Add(subject);
+
+        db.SaveChanges();
+
+        var permissionCode = $"{app.Code}:{resourceType.Code}:{action.Code}";
+        return (db, subject, parent, child, permissionCode);
+    }
+
+    [Fact]
+    public async Task SubjectWithChildRole_InheritsParentPermissions()
+    {
+        // The whole point of role inheritance: assigning the child role to a
+        // subject should grant them the parent's permissions.
+        var (db, subject, _, child, permissionCode) = BuildHierarchy();
+        db.SubjectRoles.Add(new SubjectRole { SubjectId = subject.Id, RoleId = child.Id });
+        await db.SaveChangesAsync();
+
+        var repo = new PermissionRepository(db);
+        var has = await repo.HasPermissionAsync(subject.Id, permissionCode);
+        var perms = await repo.GetPermissionsForSubjectAsync(subject.Id);
+
+        has.Should().BeTrue("child role inherits permissions of its parent");
+        perms.Should().Contain(permissionCode);
+    }
+
+    [Fact]
+    public async Task SubjectWithParentRole_DoesNotGetChildOnlyPermissions()
+    {
+        // Inversion guard: a subject who only holds the parent role must NOT
+        // gain a permission granted to a child of that parent. The previous
+        // implementation walked the relationship the wrong way and exposed
+        // child permissions to parent-role holders.
+        var (db, subject, parent, child, _) = BuildHierarchy();
+
+        // Move the permission from the parent to the child role only.
+        // RolePermission's primary key includes RoleId, so we delete-and-add
+        // rather than mutating the existing row.
+        var oldRp = db.RolePermissions.Single();
+        var permissionId = oldRp.PermissionId;
+        db.RolePermissions.Remove(oldRp);
+        await db.SaveChangesAsync();
+        db.RolePermissions.Add(new RolePermission { RoleId = child.Id, PermissionId = permissionId });
+        await db.SaveChangesAsync();
+
+        // Subject holds the parent, not the child.
+        db.SubjectRoles.Add(new SubjectRole { SubjectId = subject.Id, RoleId = parent.Id });
+        await db.SaveChangesAsync();
+
+        var repo = new PermissionRepository(db);
+        var perms = await repo.GetPermissionsForSubjectAsync(subject.Id);
+
+        perms.Should().BeEmpty("parent role must not inherit permissions granted to child roles");
+    }
+
+    [Fact]
+    public async Task GrandchildRole_InheritsGrandparentPermissions()
+    {
+        // Multi-level chain: grandparent → parent → child. Permission on the
+        // grandparent must reach the grandchild. The prior implementation
+        // capped at two levels via `ParentRole.ParentRoleId`; this test would
+        // catch a regression to that behavior.
+        var (db, subject, _, child, permissionCode) = BuildHierarchy();
+
+        var grandchild = new Role
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = child.ApplicationId,
+            Code = "grandchild",
+            Name = "Grandchild",
+            ParentRoleId = child.Id,
+        };
+        db.Roles.Add(grandchild);
+        db.SubjectRoles.Add(new SubjectRole { SubjectId = subject.Id, RoleId = grandchild.Id });
+        await db.SaveChangesAsync();
+
+        var repo = new PermissionRepository(db);
+        var has = await repo.HasPermissionAsync(subject.Id, permissionCode);
+
+        has.Should().BeTrue("multi-level chains should resolve permissions all the way to the root");
+    }
+
+    [Fact]
+    public async Task CyclicParentChain_DoesNotInfinitelyLoop()
+    {
+        // Defense against a corrupt graph: if A→B→A is somehow persisted
+        // (direct DB edit, future buggy update endpoint), permission lookups
+        // must terminate. They needn't return correct results — just not hang.
+        var (db, subject, parent, child, permissionCode) = BuildHierarchy();
+
+        parent.ParentRoleId = child.Id; // close the cycle
+        await db.SaveChangesAsync();
+
+        db.SubjectRoles.Add(new SubjectRole { SubjectId = subject.Id, RoleId = child.Id });
+        await db.SaveChangesAsync();
+
+        var repo = new PermissionRepository(db);
+
+        // Run with an explicit cancel-after timeout so the test fails fast
+        // rather than hanging if the loop ever regresses.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var has = await repo.HasPermissionAsync(subject.Id, permissionCode, ct: cts.Token);
+
+        has.Should().BeTrue("the permission is reachable via the (cyclic) parent chain");
+    }
+}

--- a/tests/Andy.Rbac.Api.Tests/Services/RoleServiceTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/RoleServiceTests.cs
@@ -106,6 +106,56 @@ public class RoleServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_WithValidParentChain_Succeeds()
+    {
+        // Issue #46 — cycle detection should not reject acyclic chains.
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var service = new RoleService(context, _loggerMock.Object);
+
+        var result = await service.CreateAsync(
+            new CreateRoleRequest("inheritor", "Inheritor", null, "test-app", ParentRoleCode: "admin"));
+
+        result.Role.Code.Should().Be("inheritor");
+        result.Role.ParentRoleCode.Should().Be("admin");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithCyclicParentChain_Throws()
+    {
+        // Issue #46 — if the parent chain has been corrupted such that the
+        // proposed parent ultimately loops back on itself, reject the create.
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+
+        // Manually build a cyclic chain a → b → a in the DB.
+        var appId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var roleA = new Andy.Rbac.Models.Role
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = appId,
+            Code = "cycle-a",
+            Name = "Cycle A",
+        };
+        var roleB = new Andy.Rbac.Models.Role
+        {
+            Id = Guid.NewGuid(),
+            ApplicationId = appId,
+            Code = "cycle-b",
+            Name = "Cycle B",
+            ParentRoleId = roleA.Id,
+        };
+        context.Roles.AddRange(roleA, roleB);
+        await context.SaveChangesAsync();
+        roleA.ParentRoleId = roleB.Id;
+        await context.SaveChangesAsync();
+
+        var service = new RoleService(context, _loggerMock.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.CreateAsync(new CreateRoleRequest(
+                "leaf", "Leaf", null, "test-app", ParentRoleCode: "cycle-a")));
+    }
+
+    [Fact]
     public async Task DeleteAsync_WithValidNonSystemRole_DeletesRole()
     {
         // Arrange


### PR DESCRIPTION
Closes #46.

## Inheritance direction was inverted

The query

```csharp
rp.RoleId in subjectRoleIds OR
rp.Role.ParentRoleId in subjectRoleIds OR
rp.Role.ParentRole.ParentRoleId in subjectRoleIds
```

was the wrong direction. The model docs say *"this role inherits all permissions from its parent"* — so a subject with role R should hold permissions of R **and of every ancestor of R**. The old query instead granted permissions of every *child* role of R to a subject holding R. It also capped at two parent levels.

## Fix — repository

- New `PermissionRepository.ExpandToAncestorsAsync(roleIds)` walks the `ParentRoleId` chain to compute the full ancestor closure of the given set. Bounded depth (32) and cycle-safe — terminates as soon as a frontier produces no new IDs.
- `GetPermissionsForSubjectAsync`, `HasPermissionAsync`, `GetPermissionsForRolesAsync`, `HasPermissionForRolesAsync` all match against the expanded set instead of the inverted three-level OR.
- Implementation is portable across providers (Postgres / SQLite / InMemory) — no recursive CTE required.

## Fix — service

- `RoleService.EnsureParentChainIsAcyclicAsync` walks from a proposed parent up the chain; throws if any role appears twice or the chain exceeds depth 32.
- Called from `CreateAsync` whenever `ParentRoleCode` is supplied. For a brand-new Create a cycle through the new role is impossible (nothing references it yet), but the helper is generic — ready for an Update endpoint, and it catches a corrupt persisted chain and fails closed instead of silently inheriting forever.

## Tests

`PermissionRepositoryInheritanceTests` (4):

- `SubjectWithChildRole_InheritsParentPermissions` — the happy path (the whole point of inheritance).
- `SubjectWithParentRole_DoesNotGetChildOnlyPermissions` — the inversion regression test.
- `GrandchildRole_InheritsGrandparentPermissions` — multi-level chain (catches a regression to the two-level cap).
- `CyclicParentChain_DoesNotInfinitelyLoop` — runs with a 5-second cancellation token; the test fails fast if termination ever regresses.

`RoleServiceTests` (2):

- `CreateAsync_WithValidParentChain_Succeeds` — cycle detection doesn't reject acyclic chains.
- `CreateAsync_WithCyclicParentChain_Throws` — manually persists `a→b→a` and confirms a Create with that chain as ancestor throws.

## Verification

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` reports 358 passing (baseline 352 + 6 new tests) / 19 pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)