### PR TITLE
[HIGH] Fail closed on misconfigured CORS origins

### DIFF
--- a/src/Andy.Rbac.Api/Configuration/CorsOriginValidator.cs
+++ b/src/Andy.Rbac.Api/Configuration/CorsOriginValidator.cs
@@ -1,0 +1,44 @@
+namespace Andy.Rbac.Api.Configuration;
+
+/// <summary>
+/// Issue #50 — startup-time check that the CORS origin list is sane for the
+/// current environment. The default CORS policy combines <c>WithOrigins</c>
+/// with <c>AllowCredentials()</c>; a wildcard origin in that combination is
+/// always wrong (browsers reject it) and an empty list in Production silently
+/// blocks legitimate clients while masking misconfiguration. Fail closed at
+/// startup instead.
+/// </summary>
+public static class CorsOriginValidator
+{
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> if <paramref name="origins"/>
+    /// contains any wildcard (or is empty in non-Development environments).
+    /// In Development, an empty list is allowed; the policy registration falls
+    /// back to a localhost default.
+    /// </summary>
+    public static void Validate(IReadOnlyList<string> origins, bool isDevelopment)
+    {
+        foreach (var origin in origins)
+        {
+            if (string.IsNullOrWhiteSpace(origin))
+            {
+                throw new InvalidOperationException(
+                    "Cors:Origins contains a blank entry. List exact origins only.");
+            }
+
+            if (origin.Contains('*'))
+            {
+                throw new InvalidOperationException(
+                    $"Cors:Origins entry '{origin}' contains a wildcard. " +
+                    "Wildcards are incompatible with AllowCredentials and are rejected by browsers; " +
+                    "list exact origins only.");
+            }
+        }
+
+        if (!isDevelopment && origins.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "Cors:Origins must be configured in non-Development environments.");
+        }
+    }
+}

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -146,18 +146,29 @@ builder.Services.Configure<Microsoft.AspNetCore.Authentication.AuthenticationOpt
 
 builder.Services.AddAuthorization();
 
-// Add CORS
+// Add CORS — fail closed on misconfigured origin lists (issue #50). Wildcards
+// in an AllowCredentials policy are silently rejected by browsers anyway; an
+// empty list in Production usually means a deploy-time config drift. Throwing
+// at startup is louder than logging.
+var configuredCorsOrigins = builder.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+Andy.Rbac.Api.Configuration.CorsOriginValidator.Validate(
+    configuredCorsOrigins, builder.Environment.IsDevelopment());
+var effectiveCorsOrigins = configuredCorsOrigins.Length > 0
+    ? configuredCorsOrigins
+    : new[] { "http://localhost:3000" };
+
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins(builder.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? ["http://localhost:3000"])
+        policy.WithOrigins(effectiveCorsOrigins)
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials();
     });
 
-    // Allow MCP clients (Claude Desktop, Cursor, etc.) to access /mcp endpoints
+    // Allow MCP clients (Claude Desktop, Cursor, etc.) to access /mcp endpoints.
+    // No AllowCredentials here — wildcard origin only works without credentials.
     options.AddPolicy("AllowMcpClients", policy =>
     {
         policy.AllowAnyOrigin()

--- a/tests/Andy.Rbac.Api.Tests/Configuration/CorsOriginValidatorTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Configuration/CorsOriginValidatorTests.cs
@@ -1,0 +1,68 @@
+using Andy.Rbac.Api.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Rbac.Api.Tests.Configuration;
+
+/// <summary>
+/// Issue #50 — startup-time guard that catches CORS origin misconfigurations
+/// that are silently dangerous when the policy also calls AllowCredentials.
+/// </summary>
+public class CorsOriginValidatorTests
+{
+    [Fact]
+    public void Validate_WithExactOrigins_DoesNotThrow()
+    {
+        var origins = new[] { "https://app.example.com", "http://localhost:5180" };
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: false);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_WithWildcardOrigin_Throws()
+    {
+        var origins = new[] { "*" };
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: false);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*wildcard*");
+    }
+
+    [Fact]
+    public void Validate_WithSubdomainWildcard_Throws()
+    {
+        // ASP.NET's WithOrigins doesn't actually support subdomain wildcards,
+        // and even if it did, mixing them with AllowCredentials is unsafe.
+        var origins = new[] { "https://*.example.com" };
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: false);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*wildcard*");
+    }
+
+    [Fact]
+    public void Validate_WithBlankEntry_Throws()
+    {
+        var origins = new[] { "https://app.example.com", "" };
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: false);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*blank*");
+    }
+
+    [Fact]
+    public void Validate_EmptyInProduction_Throws()
+    {
+        var origins = Array.Empty<string>();
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: false);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*non-Development*");
+    }
+
+    [Fact]
+    public void Validate_EmptyInDevelopment_DoesNotThrow()
+    {
+        // Local dev convenience — Program.cs falls back to a localhost origin
+        // when no config is present.
+        var origins = Array.Empty<string>();
+        var act = () => CorsOriginValidator.Validate(origins, isDevelopment: true);
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Closes #50.

## What

The default CORS policy combines `WithOrigins(...)` with `AllowAnyHeader`/`AllowAnyMethod`/`AllowCredentials`. Two silent failure modes:

- A wildcard origin (`*` or `https://*.example.com`) is invalid CORS when credentials are allowed — browsers reject it — but ASP.NET happily registers the policy and diagnosis usually blames the client.
- An empty origin list in Production almost always means deploy-time config drift; the existing localhost fallback masked the misconfiguration entirely.

## Fix

`Andy.Rbac.Api/Configuration/CorsOriginValidator.Validate(origins, isDevelopment)` runs at startup and throws `InvalidOperationException` for either case. A blank entry in the list also throws as a typo guard. The localhost fallback in Program.cs is Development-only.

## Tests

6 new tests in `CorsOriginValidatorTests`:
- exact origins → no throw
- wildcard `*` → throw
- subdomain wildcard `https://*.example.com` → throw
- blank entry in list → throw
- empty list in Production → throw
- empty list in Development → no throw

## Verification

- [x] `dotnet build` clean.
- [x] `dotnet test` reports 364 passing (baseline 358 + 6 new) / 19 pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)