### PR TITLE
Repair the 19 stale test failures

### DIFF
--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -44,21 +44,21 @@ public class DataSeederTests
     }
 
     [Fact]
-    public async Task SeedAsync_SeedsApplications()
+    public async Task SeedAsync_SeedsLegacyApplications()
     {
-        // Arrange
+        // SeedAsync only seeds the consumer apps and out-of-scope services
+        // that don't yet ship a config/registration.json. Every other Andy
+        // service (auth, docs, rbac, etc.) is now seeded by
+        // SeedFromManifestsAsync — exercised in the manifest tests below.
         using var context = CreateContext();
 
-        // Act
         await DataSeeder.SeedAsync(context);
 
-        // Assert
         var apps = await context.Applications.ToListAsync();
-        apps.Should().Contain(a => a.Code == "andy-auth");
-        apps.Should().Contain(a => a.Code == "andy-docs");
         apps.Should().Contain(a => a.Code == "andy-cli");
         apps.Should().Contain(a => a.Code == "andy-agentic-web");
-        apps.Should().Contain(a => a.Code == "andy-rbac");
+        apps.Should().Contain(a => a.Code == "subscription");
+        apps.Should().Contain(a => a.Code == "narration");
     }
 
     [Fact]
@@ -91,38 +91,17 @@ public class DataSeederTests
         var actions = await context.Actions.Where(a => a.Code == "read").ToListAsync();
         actions.Should().ContainSingle();
 
-        var apps = await context.Applications.Where(a => a.Code == "andy-docs").ToListAsync();
+        // Use a legacy app that SeedAsync still seeds directly. andy-docs is
+        // manifest-driven now, so it would be absent here.
+        var apps = await context.Applications.Where(a => a.Code == "andy-cli").ToListAsync();
         apps.Should().ContainSingle();
 
         var roles = await context.Roles.Where(r => r.Code == "super-admin" && r.ApplicationId == null).ToListAsync();
         roles.Should().ContainSingle();
     }
 
-    [Fact]
-    public async Task SeedApplicationDataAsync_WithAndyDocs_SeedsResourceTypesAndRoles()
-    {
-        // Arrange
-        using var context = CreateContext();
-        await DataSeeder.SeedAsync(context);
-
-        // Act
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-docs");
-
-        // Assert
-        var app = await context.Applications
-            .Include(a => a.ResourceTypes)
-            .Include(a => a.Roles)
-            .FirstOrDefaultAsync(a => a.Code == "andy-docs");
-
-        app.Should().NotBeNull();
-        app!.ResourceTypes.Should().Contain(rt => rt.Code == "document");
-        app.ResourceTypes.Should().Contain(rt => rt.Code == "collection");
-        app.ResourceTypes.Should().Contain(rt => rt.Code == "template");
-
-        app.Roles.Should().Contain(r => r.Code == "admin");
-        app.Roles.Should().Contain(r => r.Code == "editor");
-        app.Roles.Should().Contain(r => r.Code == "viewer");
-    }
+    // SeedApplicationDataAsync_WithAndyDocs_*: removed — andy-docs is now
+    // manifest-driven via SeedFromManifestsAsync.
 
     [Fact]
     public async Task SeedApplicationDataAsync_WithAndyCli_SeedsResourceTypesAndRoles()
@@ -150,30 +129,8 @@ public class DataSeederTests
         app.Roles.Should().Contain(r => r.Code == "restricted");
     }
 
-    [Fact]
-    public async Task SeedApplicationDataAsync_WithAndyAuth_SeedsResourceTypesAndRoles()
-    {
-        // Arrange
-        using var context = CreateContext();
-        await DataSeeder.SeedAsync(context);
-
-        // Act
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-auth");
-
-        // Assert
-        var app = await context.Applications
-            .Include(a => a.ResourceTypes)
-            .Include(a => a.Roles)
-            .FirstOrDefaultAsync(a => a.Code == "andy-auth");
-
-        app.Should().NotBeNull();
-        app!.ResourceTypes.Should().Contain(rt => rt.Code == "user");
-        app.ResourceTypes.Should().Contain(rt => rt.Code == "client");
-        app.ResourceTypes.Should().Contain(rt => rt.Code == "scope");
-
-        app.Roles.Should().Contain(r => r.Code == "admin");
-        app.Roles.Should().Contain(r => r.Code == "user-manager");
-    }
+    // SeedApplicationDataAsync_WithAndyAuth_*: removed — andy-auth is now
+    // manifest-driven via SeedFromManifestsAsync.
 
     [Fact]
     public async Task SeedApplicationDataAsync_WithAndyAgenticWeb_SeedsResourceTypesAndRoles()
@@ -214,39 +171,34 @@ public class DataSeederTests
     [Fact]
     public async Task SeedApplicationDataAsync_IsIdempotent()
     {
-        // Arrange
         using var context = CreateContext();
         await DataSeeder.SeedAsync(context);
 
-        // Act - run twice
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-docs");
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-docs");
+        // andy-cli is one of the legacy apps still handled by
+        // SeedApplicationDataAsync's switch.
+        await DataSeeder.SeedApplicationDataAsync(context, "andy-cli");
+        await DataSeeder.SeedApplicationDataAsync(context, "andy-cli");
 
-        // Assert - should not create duplicates
         var app = await context.Applications
             .Include(a => a.ResourceTypes)
             .Include(a => a.Roles)
-            .FirstOrDefaultAsync(a => a.Code == "andy-docs");
+            .FirstOrDefaultAsync(a => a.Code == "andy-cli");
 
-        var docTypes = app!.ResourceTypes.Where(rt => rt.Code == "document").ToList();
-        docTypes.Should().ContainSingle();
-
-        var adminRoles = app.Roles.Where(r => r.Code == "admin").ToList();
-        adminRoles.Should().ContainSingle();
+        app!.ResourceTypes.Where(rt => rt.Code == "config").Should().ContainSingle();
+        app.Roles.Where(r => r.Code == "admin").Should().ContainSingle();
     }
 
     [Fact]
     public async Task SeedApplicationDataAsync_ResourceTypes_HaveCorrectSupportsInstancesValue()
     {
-        // Arrange
         using var context = CreateContext();
         await DataSeeder.SeedAsync(context);
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-docs");
         await DataSeeder.SeedApplicationDataAsync(context, "andy-cli");
 
-        // Assert
-        var docType = await context.ResourceTypes.FirstOrDefaultAsync(rt => rt.Code == "document");
-        docType!.SupportsInstances.Should().BeTrue();
+        // Different apps mark different types as instance-capable; verify
+        // that nuance survives seeding.
+        var sessionType = await context.ResourceTypes.FirstOrDefaultAsync(rt => rt.Code == "session");
+        sessionType!.SupportsInstances.Should().BeTrue();
 
         var configType = await context.ResourceTypes.FirstOrDefaultAsync(rt => rt.Code == "config");
         configType!.SupportsInstances.Should().BeFalse();
@@ -273,15 +225,13 @@ public class DataSeederTests
     [Fact]
     public async Task SeedApplicationDataAsync_Roles_AreSystemRoles()
     {
-        // Arrange
         using var context = CreateContext();
         await DataSeeder.SeedAsync(context);
-        await DataSeeder.SeedApplicationDataAsync(context, "andy-docs");
+        await DataSeeder.SeedApplicationDataAsync(context, "andy-cli");
 
-        // Assert
         var app = await context.Applications
             .Include(a => a.Roles)
-            .FirstOrDefaultAsync(a => a.Code == "andy-docs");
+            .FirstOrDefaultAsync(a => a.Code == "andy-cli");
 
         app!.Roles.Should().OnlyContain(r => r.IsSystem);
     }

--- a/tests/Andy.Rbac.Api.Tests/Integration/ApplicationsControllerTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/ApplicationsControllerTests.cs
@@ -23,7 +23,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var applications = await response.Content.ReadFromJsonAsync<List<ApplicationSummary>>();
+        var applications = await response.Content.ReadFromJsonAsync<List<ApplicationSummary>>(TestJsonOptions.Default);
         applications.Should().NotBeNull();
         applications.Should().Contain(a => a.Code == "test-app");
     }
@@ -39,7 +39,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>();
+        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>(TestJsonOptions.Default);
         application.Should().NotBeNull();
         application!.Code.Should().Be("test-app");
         application.Name.Should().Be("Test Application");
@@ -63,7 +63,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>();
+        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>(TestJsonOptions.Default);
         application.Should().NotBeNull();
         application!.Code.Should().Be("test-app");
     }
@@ -89,7 +89,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>();
+        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>(TestJsonOptions.Default);
         application.Should().NotBeNull();
         application!.Code.Should().Be(request.Code);
         application.Name.Should().Be("New Application");
@@ -120,7 +120,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>();
+        var application = await response.Content.ReadFromJsonAsync<ApplicationDetail>(TestJsonOptions.Default);
         application.Should().NotBeNull();
         application!.Name.Should().Be("Updated Test Application");
     }
@@ -144,7 +144,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
         // Arrange - create an app to delete
         var createRequest = new CreateApplicationRequest($"delete-app-{Guid.NewGuid():N}", "Delete Me");
         var createResponse = await _client.PostAsJsonAsync("/api/applications", createRequest);
-        var created = await createResponse.Content.ReadFromJsonAsync<ApplicationDetail>();
+        var created = await createResponse.Content.ReadFromJsonAsync<ApplicationDetail>(TestJsonOptions.Default);
 
         // Act
         var response = await _client.DeleteAsync($"/api/applications/{created!.Id}");
@@ -179,7 +179,7 @@ public class ApplicationsControllerTests : IClassFixture<RbacWebApplicationFacto
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var resourceType = await response.Content.ReadFromJsonAsync<ResourceTypeSummary>();
+        var resourceType = await response.Content.ReadFromJsonAsync<ResourceTypeSummary>(TestJsonOptions.Default);
         resourceType.Should().NotBeNull();
         resourceType!.Code.Should().Be(request.Code);
     }

--- a/tests/Andy.Rbac.Api.Tests/Integration/CheckControllerTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/CheckControllerTests.cs
@@ -26,7 +26,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>();
+        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Allowed.Should().BeTrue();
     }
@@ -42,7 +42,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>();
+        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Allowed.Should().BeFalse();
     }
@@ -58,7 +58,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>();
+        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Allowed.Should().BeFalse();
         result.Reason.Should().Be("Subject not found");
@@ -75,7 +75,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>();
+        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Allowed.Should().BeTrue();
     }
@@ -91,7 +91,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>();
+        var result = await response.Content.ReadFromJsonAsync<CheckPermissionResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Allowed.Should().BeFalse();
     }
@@ -104,7 +104,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Permissions.Should().NotBeEmpty();
         result.Permissions.Should().Contain(p => p.Contains("document:read"));
@@ -118,7 +118,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Permissions.Should().OnlyContain(p => p.StartsWith("test-app:"));
     }
@@ -131,7 +131,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetPermissionsResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Permissions.Should().BeEmpty();
     }
@@ -144,7 +144,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Roles.Should().Contain("admin");
     }
@@ -157,7 +157,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Roles.Should().BeEmpty();
     }
@@ -170,7 +170,7 @@ public class CheckControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>();
+        var result = await response.Content.ReadFromJsonAsync<GetRolesResponse>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Roles.Should().BeEmpty();
     }

--- a/tests/Andy.Rbac.Api.Tests/Integration/RolesControllerTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/RolesControllerTests.cs
@@ -24,7 +24,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var roles = await response.Content.ReadFromJsonAsync<List<RoleDetail>>();
+        var roles = await response.Content.ReadFromJsonAsync<List<RoleDetail>>(TestJsonOptions.Default);
         roles.Should().NotBeNull();
         roles.Should().Contain(r => r.Code == "admin");
         roles.Should().Contain(r => r.Code == "editor");
@@ -39,7 +39,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var roles = await response.Content.ReadFromJsonAsync<List<RoleDetail>>();
+        var roles = await response.Content.ReadFromJsonAsync<List<RoleDetail>>(TestJsonOptions.Default);
         roles.Should().NotBeNull();
         roles.Should().NotBeEmpty();
     }
@@ -55,7 +55,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var role = await response.Content.ReadFromJsonAsync<RoleDetail>();
+        var role = await response.Content.ReadFromJsonAsync<RoleDetail>(TestJsonOptions.Default);
         role.Should().NotBeNull();
         role!.Code.Should().Be("admin");
         role.IsSystem.Should().BeTrue();
@@ -79,7 +79,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var role = await response.Content.ReadFromJsonAsync<RoleDetail>();
+        var role = await response.Content.ReadFromJsonAsync<RoleDetail>(TestJsonOptions.Default);
         role.Should().NotBeNull();
         role!.Code.Should().Be("admin");
     }
@@ -105,7 +105,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var role = await response.Content.ReadFromJsonAsync<RoleDetail>();
+        var role = await response.Content.ReadFromJsonAsync<RoleDetail>(TestJsonOptions.Default);
         role.Should().NotBeNull();
         role!.Code.Should().Be(request.Code);
         role.IsSystem.Should().BeFalse();
@@ -143,7 +143,7 @@ public class RolesControllerTests : IClassFixture<RbacWebApplicationFactory>
         // Arrange - create a non-system role to delete
         var createRequest = new CreateRoleRequest($"delete-role-{Guid.NewGuid():N}", "Delete Me", null, "test-app");
         var createResponse = await _client.PostAsJsonAsync("/api/roles", createRequest);
-        var created = await createResponse.Content.ReadFromJsonAsync<RoleDetail>();
+        var created = await createResponse.Content.ReadFromJsonAsync<RoleDetail>(TestJsonOptions.Default);
 
         // Act
         var response = await _client.DeleteAsync($"/api/roles/{created!.Id}");

--- a/tests/Andy.Rbac.Api.Tests/Integration/SubjectsControllerTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/SubjectsControllerTests.cs
@@ -24,7 +24,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>();
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Items.Should().NotBeEmpty();
         result.Items.Should().Contain(s => s.ExternalId == "admin-user");
@@ -38,7 +38,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>();
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Items.Should().Contain(s => s.ExternalId == "admin-user");
     }
@@ -51,7 +51,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>();
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Items.Should().OnlyContain(s => s.Provider == "test-provider");
     }
@@ -64,7 +64,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>();
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<SubjectDto>>(TestJsonOptions.Default);
         result.Should().NotBeNull();
         result!.Items.Should().HaveCountLessOrEqualTo(2);
         result.Skip.Should().Be(0);
@@ -82,7 +82,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var subject = await response.Content.ReadFromJsonAsync<SubjectDetailDto>();
+        var subject = await response.Content.ReadFromJsonAsync<SubjectDetailDto>(TestJsonOptions.Default);
         subject.Should().NotBeNull();
         subject!.ExternalId.Should().Be("admin-user");
         subject.Roles.Should().Contain(r => r.RoleCode == "admin");
@@ -106,7 +106,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var subject = await response.Content.ReadFromJsonAsync<SubjectDetailDto>();
+        var subject = await response.Content.ReadFromJsonAsync<SubjectDetailDto>(TestJsonOptions.Default);
         subject.Should().NotBeNull();
         subject!.ExternalId.Should().Be("admin-user");
     }
@@ -137,7 +137,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>();
+        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>(TestJsonOptions.Default);
         subject.Should().NotBeNull();
         subject!.ExternalId.Should().Be(request.ExternalId);
         subject.Email.Should().Be("new@test.com");
@@ -159,7 +159,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>();
+        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>(TestJsonOptions.Default);
         subject.Should().NotBeNull();
         subject!.Email.Should().Be("updated-admin@test.com");
     }
@@ -176,7 +176,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>();
+        var subject = await response.Content.ReadFromJsonAsync<SubjectDto>(TestJsonOptions.Default);
         subject.Should().NotBeNull();
         subject!.Email.Should().Be("new-email@test.com");
     }
@@ -208,7 +208,7 @@ public class SubjectsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Verify deactivation
         var getResponse = await _client.GetAsync($"/api/subjects/{noRoleId}");
-        var subject = await getResponse.Content.ReadFromJsonAsync<SubjectDetailDto>();
+        var subject = await getResponse.Content.ReadFromJsonAsync<SubjectDetailDto>(TestJsonOptions.Default);
         subject!.IsActive.Should().BeFalse();
     }
 

--- a/tests/Andy.Rbac.Api.Tests/Integration/TeamsControllerTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/TeamsControllerTests.cs
@@ -24,7 +24,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var teams = await response.Content.ReadFromJsonAsync<List<TeamDto>>();
+        var teams = await response.Content.ReadFromJsonAsync<List<TeamDto>>(TestJsonOptions.Default);
         teams.Should().NotBeNull();
         teams.Should().Contain(t => t.Code == "test-team");
     }
@@ -40,7 +40,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var team = await response.Content.ReadFromJsonAsync<TeamDetailDto>();
+        var team = await response.Content.ReadFromJsonAsync<TeamDetailDto>(TestJsonOptions.Default);
         team.Should().NotBeNull();
         team!.Code.Should().Be("test-team");
         team.Members.Should().Contain(m => m.SubjectExternalId == "editor-user");
@@ -64,7 +64,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var team = await response.Content.ReadFromJsonAsync<TeamDetailDto>();
+        var team = await response.Content.ReadFromJsonAsync<TeamDetailDto>(TestJsonOptions.Default);
         team.Should().NotBeNull();
         team!.Code.Should().Be("test-team");
     }
@@ -90,7 +90,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var team = await response.Content.ReadFromJsonAsync<TeamDto>();
+        var team = await response.Content.ReadFromJsonAsync<TeamDto>(TestJsonOptions.Default);
         team.Should().NotBeNull();
         team!.Code.Should().Be(request.Code);
         team.Name.Should().Be("New Team");
@@ -120,7 +120,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var team = await response.Content.ReadFromJsonAsync<TeamDto>();
+        var team = await response.Content.ReadFromJsonAsync<TeamDto>(TestJsonOptions.Default);
         team.Should().NotBeNull();
         team!.ParentTeamCode.Should().Be("test-team");
     }
@@ -150,7 +150,7 @@ public class TeamsControllerTests : IClassFixture<RbacWebApplicationFactory>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var team = await response.Content.ReadFromJsonAsync<TeamDto>();
+        var team = await response.Content.ReadFromJsonAsync<TeamDto>(TestJsonOptions.Default);
         team.Should().NotBeNull();
         team!.Name.Should().Be("Updated Team Name");
     }

--- a/tests/Andy.Rbac.Api.Tests/Integration/TestJsonOptions.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/TestJsonOptions.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Rbac.Api.Tests.Integration;
+
+/// <summary>
+/// Mirror of the API's JSON options. Program.cs registers a
+/// <see cref="JsonStringEnumConverter"/> on the controller pipeline; without
+/// the same converter on the read side, <c>ReadFromJsonAsync&lt;T&gt;</c>
+/// chokes on string-encoded enums (e.g. <c>"User"</c> →
+/// <see cref="Andy.Rbac.Models.SubjectType"/>).
+/// </summary>
+public static class TestJsonOptions
+{
+    public static readonly JsonSerializerOptions Default = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+}


### PR DESCRIPTION
Closes the long-running "19 pre-existing failures" baseline that has been the noise floor in every CI run for weeks. Two unrelated root causes had been masking each other.

## (1) Integration tests deserialize without the API's enum converter — 12 tests

`Program.cs` registers `JsonStringEnumConverter` on the controller pipeline, so responses serialize enums as strings (`SubjectType.User` → `"User"`, `TeamMembershipRole.Member` → `"Member"`). The integration tests called `response.Content.ReadFromJsonAsync<T>()` with default JSON options — which can't read those strings back and threw `JsonException`.

- New `tests/Integration/TestJsonOptions.Default` mirrors the API's converter set.
- All 40 `ReadFromJsonAsync<T>()` call sites in `Applications/Check/Roles/Subjects/TeamsControllerTests` now pass `TestJsonOptions.Default`.

This unblocks 10 SubjectsControllerTests + 2 TeamsControllerTests.

## (2) DataSeederTests reflect the pre-manifest seeder shape — 7 tests

The data layer was refactored months ago: only "consumer apps and out-of-scope services without a config/registration.json" remain in `SeedAsync` / `SeedApplicationDataAsync` (andy-cli, andy-agentic-web, subscription, narration). Every other Andy service is seeded by `SeedFromManifestsAsync` from its registration manifest. The 7 failing tests still asserted on andy-auth / andy-docs / andy-rbac being seeded by the legacy paths.

- `SeedAsync_SeedsApplications` → `_SeedsLegacyApplications`, expectations narrowed to the 4 apps that path actually still touches.
- `SeedAsync_IsIdempotent` query switched from andy-docs to andy-cli (a legacy app) so the assertion is meaningful.
- `SeedApplicationDataAsync_WithAndyDocs_*` and `_WithAndyAuth_*` removed (manifest-driven now).
- `_IsIdempotent` / `_ResourceTypes_HaveCorrectSupportsInstancesValue` / `_Roles_AreSystemRoles` rewritten against andy-cli.

## Verification

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` reports **387 passing / 0 failing** — was 364 / 19 before this PR.

Net gain: 12 fixed-by-converter, 7 fixed-by-rewrite-or-delete; total tests dropped from 389 to 387 because two andy-docs/andy-auth tests were deleted as obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)