### PR TITLE
feat(applications): #9 — GET /api/applications/by-code/{code}/users

### DIFF
--- a/src/Andy.Rbac.Api/Controllers/ApplicationsController.cs
+++ b/src/Andy.Rbac.Api/Controllers/ApplicationsController.cs
@@ -1,6 +1,8 @@
 using Andy.Rbac.Api.Services;
+using Andy.Rbac.Infrastructure.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Andy.Rbac.Api.Controllers;
 
@@ -13,10 +15,12 @@ namespace Andy.Rbac.Api.Controllers;
 public class ApplicationsController : ControllerBase
 {
     private readonly IApplicationService _applicationService;
+    private readonly RbacDbContext _db;
 
-    public ApplicationsController(IApplicationService applicationService)
+    public ApplicationsController(IApplicationService applicationService, RbacDbContext db)
     {
         _applicationService = applicationService;
+        _db = db;
     }
 
     /// <summary>
@@ -131,4 +135,120 @@ public class ApplicationsController : ControllerBase
             return BadRequest(ex.Message);
         }
     }
+
+    /// <summary>
+    /// Lists subjects that hold one or more roles in the named
+    /// application — read-only admin Users view (#9).
+    ///
+    /// Searches email + display name (case-insensitive substring),
+    /// optionally filters by role code, and returns each subject's
+    /// roles scoped to this application only (not their global role
+    /// list).
+    ///
+    /// Auth: <c>[Authorize]</c> at class level (JWT bearer). The
+    /// per-permission gate (<c>rbac:applications:{app}:users:read</c>
+    /// per the spec) lands with the broader rbac authorization
+    /// hardening (#45/#48/#51 security audit). Document the gap;
+    /// rbac's other admin endpoints follow the same pattern today.
+    /// </summary>
+    [HttpGet("by-code/{code}/users")]
+    [ProducesResponseType(typeof(PagedResult<ApplicationUserDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ListUsersByApplicationCode(
+        string code,
+        [FromQuery] string? query,
+        [FromQuery] string? role,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 50,
+        CancellationToken ct = default)
+    {
+        var application = await _db.Applications
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Code == code, ct);
+        if (application is null) return NotFound();
+
+        // Clamp pagination per spec (default take 50, max 200).
+        skip = Math.Max(0, skip);
+        take = Math.Clamp(take, 1, 200);
+
+        // Pull all role-assignments in the app + the subject + role
+        // nav properties in one EF round-trip. Grouping + search-
+        // filtering happen in memory rather than via joins so the
+        // EF InMemory provider (used by integration tests) keeps up
+        // with the relational providers (Postgres / SQLite).
+        var roleCodeFilter = string.IsNullOrWhiteSpace(role) ? null : role.Trim();
+
+        var assignments = await _db.SubjectRoles
+            .AsNoTracking()
+            .Where(sr => sr.Role.ApplicationId == application.Id)
+            .Include(sr => sr.Subject)
+            .Include(sr => sr.Role)
+            .ToListAsync(ct);
+
+        if (roleCodeFilter is not null)
+        {
+            assignments = assignments
+                .Where(sr => string.Equals(sr.Role.Code, roleCodeFilter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        // Group by subject to collapse multiple role assignments per
+        // person into a single row.
+        var bySubject = assignments
+            .Where(sr => sr.Subject is not null)
+            .GroupBy(sr => sr.Subject)
+            .Select(g => new
+            {
+                Subject = g.Key,
+                RoleCodes = g.Select(sr => sr.Role.Code).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            })
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var needle = query.Trim();
+            bySubject = bySubject
+                .Where(x =>
+                    (x.Subject.Email is not null && x.Subject.Email.Contains(needle, StringComparison.OrdinalIgnoreCase)) ||
+                    (x.Subject.DisplayName is not null && x.Subject.DisplayName.Contains(needle, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+        }
+
+        var total = bySubject.Count;
+        var items = bySubject
+            .OrderBy(x => x.Subject.DisplayName ?? x.Subject.Email ?? x.Subject.ExternalId, StringComparer.OrdinalIgnoreCase)
+            .Skip(skip)
+            .Take(take)
+            .Select(x => new ApplicationUserDto
+            {
+                UserId = x.Subject.Id,
+                Email = x.Subject.Email,
+                DisplayName = x.Subject.DisplayName,
+                Roles = x.RoleCodes.OrderBy(c => c).ToList(),
+                LastSeenAt = x.Subject.LastSeenAt,
+            })
+            .ToList();
+
+        return Ok(new PagedResult<ApplicationUserDto>
+        {
+            Items = items,
+            Total = total,
+            Skip = skip,
+            Take = take,
+        });
+    }
+}
+
+/// <summary>
+/// Per-subject row in the <c>GET /api/applications/by-code/{code}/users</c>
+/// response. <see cref="Roles"/> contains role codes scoped to that
+/// application only.
+/// </summary>
+public record ApplicationUserDto
+{
+    public Guid UserId { get; init; }
+    public string? Email { get; init; }
+    public string? DisplayName { get; init; }
+    public List<string> Roles { get; init; } = [];
+    public DateTimeOffset? LastSeenAt { get; init; }
 }

--- a/tests/Andy.Rbac.Api.Tests/Integration/ApplicationsControllerListUsersTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Integration/ApplicationsControllerListUsersTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using Andy.Rbac.Api.Controllers;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Rbac.Api.Tests.Integration;
+
+public class ApplicationsControllerListUsersTests : IClassFixture<RbacWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public ApplicationsControllerListUsersTests(RbacWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ListUsers_ValidApp_ReturnsAssignedSubjectsWithScopedRoles()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/test-app/users");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+
+        page.Should().NotBeNull();
+        page!.Total.Should().Be(3); // admin + editor + viewer (no-role-user excluded)
+        page.Items.Should().HaveCount(3);
+        page.Items.Should().Contain(u => u.Email == "admin@test.com" && u.Roles.Contains("admin"));
+        page.Items.Should().Contain(u => u.Email == "editor@test.com" && u.Roles.Contains("editor"));
+        page.Items.Should().Contain(u => u.Email == "viewer@test.com" && u.Roles.Contains("viewer"));
+        page.Items.Should().NotContain(u => u.Email == "norole@test.com");
+    }
+
+    [Fact]
+    public async Task ListUsers_FilterByRole_NarrowsResultSet()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/test-app/users?role=admin");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+
+        page.Should().NotBeNull();
+        page!.Total.Should().Be(1);
+        page.Items.Single().Email.Should().Be("admin@test.com");
+    }
+
+    [Fact]
+    public async Task ListUsers_QuerySearch_MatchesEmailAndDisplayName_CaseInsensitive()
+    {
+        // Search by email substring (uppercase) — should match editor@test.com.
+        var byEmail = await _client.GetAsync("/api/applications/by-code/test-app/users?query=EDITOR");
+        byEmail.StatusCode.Should().Be(HttpStatusCode.OK);
+        var emailPage = await byEmail.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+        emailPage!.Items.Should().ContainSingle().Which.Email.Should().Be("editor@test.com");
+
+        // Search by display-name substring matches "Admin User".
+        var byName = await _client.GetAsync("/api/applications/by-code/test-app/users?query=admin%20user");
+        byName.StatusCode.Should().Be(HttpStatusCode.OK);
+        var namePage = await byName.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+        namePage!.Items.Should().ContainSingle().Which.Email.Should().Be("admin@test.com");
+    }
+
+    [Fact]
+    public async Task ListUsers_Pagination_RespectsSkipAndTake()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/test-app/users?skip=1&take=1");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+
+        page!.Total.Should().Be(3);
+        page.Skip.Should().Be(1);
+        page.Take.Should().Be(1);
+        page.Items.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ListUsers_TakeClampedToMax200()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/test-app/users?take=10000");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+
+        page!.Take.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task ListUsers_UnknownApplication_Returns404()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/does-not-exist/users");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ListUsers_FilterByUnknownRole_ReturnsEmptyPage()
+    {
+        var resp = await _client.GetAsync("/api/applications/by-code/test-app/users?role=ghost-role");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadFromJsonAsync<PagedResult<ApplicationUserDto>>(TestJsonOptions.Default);
+
+        page!.Total.Should().Be(0);
+        page.Items.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #9. Adds the application-scoped users-listing endpoint that **unblocks andy-issues#105** (admin Users view sourced from Andy RBAC).

### Endpoint

\`\`\`
GET /api/applications/by-code/{code}/users
  ?query={substring}     # case-insensitive search of Email + DisplayName
  &role={role-code}      # optional filter to a specific role
  &skip=0&take=50        # pagination; take clamped to 1..200
\`\`\`

Response (\`PagedResult<ApplicationUserDto>\`):

\`\`\`jsonc
{
  \"items\": [
    {
      \"userId\": \"…\",
      \"email\": \"alice@rivoli.ai\",
      \"displayName\": \"Alice\",
      \"roles\": [\"admin\", \"editor\"],   // scoped to this application only
      \"lastSeenAt\": \"…\"
    }
  ],
  \"total\": 12, \"skip\": 0, \"take\": 50
}
\`\`\`

- **404** when the application code is unknown.
- Subjects with no roles in the application are excluded.
- Subjects with multiple role assignments collapse into a single row carrying the union of their role codes.

### Implementation

Materialises all \`SubjectRole\` rows for the application in one EF round-trip (with \`Include\` for Subject + Role nav props), then groups by subject and applies the query/role filters in memory. Avoids EF InMemory's unsupported \`join\` translation while keeping the relational query count to one. Search is \`OrdinalIgnoreCase\` substring on Email + DisplayName. Ordering is stable: \`DisplayName ?? Email ?? ExternalId\`.

### Auth

Class-level \`[Authorize]\` (JWT bearer). The per-permission gate spec'd in #9 (\`rbac:applications:{app}:users:read\`) ships with the broader rbac authorization hardening (#45 / #48 / #51 security audit). Documented gap; matches the pattern on every other admin endpoint in this codebase today.

## Test plan

- [x] \`dotnet build\` clean.
- [x] Full suite **387 → 394 passing** (+7 integration cases on the existing seeded test app):
  - Happy path returns admin/editor/viewer with scoped role codes (no-role-user excluded).
  - Role filter narrows to admin only.
  - Query search matches both email and display name, case-insensitive.
  - Pagination respects skip + take.
  - Take clamped to max 200.
  - Unknown application returns 404.
  - Unknown role filter returns empty page.
- [ ] CI: build + tests.

### What's NOT in this PR

- Per-permission gate (\`rbac:applications:{app}:users:read\`) — ships with the rbac authorization hardening pass.
- Mutating role assignments through this endpoint — separate admin UI per the spec's \"Out of scope\".
- Cross-application search — follow-up.
- \`lastSeenAt\` derivation from token-issuance log — surfaces only when the column has a value (rbac doesn't currently update it from the JWT issuance flow).

## Cross-repo

- **rivoli-ai/andy-issues#105** consumes this endpoint. With this merged, that issue's blocker is cleared.