### PR TITLE
feat(messaging): AL1–AL4 — NATS event publishing for role lifecycle

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,5 +48,13 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <!-- Messaging (Epic AL — AL1 NATS publish + AL2 transactional outbox) -->
+    <PackageVersion Include="NATS.Net" Version="2.7.3" />
+    <PackageVersion Include="NATS.Client.Core" Version="2.7.3" />
+    <PackageVersion Include="NATS.Client.JetStream" Version="2.7.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -3,7 +3,9 @@ using Andy.Rbac.Api.Mcp;
 using Andy.Rbac.Api.Middleware;
 using Andy.Rbac.Api.Services;
 using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Infrastructure.Messaging;
 using Andy.Rbac.Infrastructure.Repositories;
+using Andy.Rbac.Messaging;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using ModelContextProtocol.AspNetCore.Authentication;
@@ -56,6 +58,33 @@ builder.Services.AddScoped<IApplicationService, ApplicationService>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<ITeamService, TeamService>();
 builder.Services.AddScoped<ISubjectService, SubjectService>();
+
+// Epic AL — NATS messaging substrate.
+//
+// AL1: IMessageBus (NATS or in-memory). The InMemoryMessageBus default
+//      keeps tests + the embedded Conductor launcher running without
+//      needing nats-server up. Production wiring binds Messaging:Nats
+//      and swaps in NatsMessageBus + NatsStreamProvisioner.
+// AL2: OutboxDispatcher background worker drains the OutboxEntry table
+//      to whichever IMessageBus is registered.
+// AL3 + AL4: IRbacEventPublisher stages outbox rows for Role/SubjectRole
+//      events; RoleService is the only caller today.
+builder.Services.Configure<NatsOptions>(builder.Configuration.GetSection(NatsOptions.SectionName));
+builder.Services.Configure<OutboxDispatcherOptions>(builder.Configuration.GetSection(OutboxDispatcherOptions.SectionName));
+
+var natsUrl = builder.Configuration[$"{NatsOptions.SectionName}:Url"];
+if (!string.IsNullOrWhiteSpace(natsUrl))
+{
+    builder.Services.AddSingleton<IMessageBus, NatsMessageBus>();
+    builder.Services.AddHostedService<NatsStreamProvisioner>();
+}
+else
+{
+    builder.Services.AddSingleton<IMessageBus, InMemoryMessageBus>();
+}
+
+builder.Services.AddScoped<IRbacEventPublisher, RbacEventPublisher>();
+builder.Services.AddHostedService<OutboxDispatcher>();
 
 // Add MCP Server for AI assistant integration
 builder.Services

--- a/src/Andy.Rbac.Api/Services/RoleService.cs
+++ b/src/Andy.Rbac.Api/Services/RoleService.cs
@@ -1,4 +1,6 @@
 using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Messaging;
+using Andy.Rbac.Messaging.Events;
 using Andy.Rbac.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,11 +13,13 @@ public class RoleService : IRoleService
 {
     private readonly RbacDbContext _db;
     private readonly ILogger<RoleService> _logger;
+    private readonly IRbacEventPublisher _events;
 
-    public RoleService(RbacDbContext db, ILogger<RoleService> logger)
+    public RoleService(RbacDbContext db, ILogger<RoleService> logger, IRbacEventPublisher events)
     {
         _db = db;
         _logger = logger;
+        _events = events;
     }
 
     public async Task<RoleListResult> GetAllAsync(string? applicationCode = null, CancellationToken ct = default)
@@ -127,6 +131,14 @@ public class RoleService : IRoleService
         };
 
         _db.Roles.Add(role);
+        _events.RoleCreated(new RoleCreated(
+            RoleId: role.Id,
+            Code: role.Code,
+            Name: role.Name,
+            ApplicationCode: request.ApplicationCode,
+            ParentRoleCode: request.ParentRoleCode,
+            IsSystem: role.IsSystem,
+            OccurredAt: DateTimeOffset.UtcNow));
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation("Created role {RoleCode}", role.Code);
@@ -182,7 +194,17 @@ public class RoleService : IRoleService
         if (role.IsSystem)
             throw new InvalidOperationException("Cannot delete system roles");
 
+        var appCode = await _db.Applications
+            .Where(a => a.Id == role.ApplicationId)
+            .Select(a => a.Code)
+            .FirstOrDefaultAsync(ct);
+
         _db.Roles.Remove(role);
+        _events.RoleDeleted(new RoleDeleted(
+            RoleId: role.Id,
+            Code: role.Code,
+            ApplicationCode: appCode,
+            OccurredAt: DateTimeOffset.UtcNow));
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation("Deleted role {RoleCode}", role.Code);
@@ -206,12 +228,22 @@ public class RoleService : IRoleService
         if (existing)
             return $"Role '{roleCode}' is already assigned to user";
 
-        _db.SubjectRoles.Add(new SubjectRole
+        var assignment = new SubjectRole
         {
+            Id = Guid.NewGuid(),
             SubjectId = subject.Id,
             RoleId = role.Id,
             ResourceInstanceId = resourceInstanceId
-        });
+        };
+        _db.SubjectRoles.Add(assignment);
+        _events.RoleAssigned(new RoleAssigned(
+            AssignmentId: assignment.Id,
+            SubjectId: subject.Id,
+            SubjectExternalId: subject.ExternalId,
+            RoleId: role.Id,
+            RoleCode: role.Code,
+            ResourceInstanceId: resourceInstanceId,
+            OccurredAt: DateTimeOffset.UtcNow));
 
         await _db.SaveChangesAsync(ct);
 
@@ -237,6 +269,14 @@ public class RoleService : IRoleService
             return $"Role '{roleCode}' is not assigned to user";
 
         _db.SubjectRoles.Remove(assignment);
+        _events.RoleRevoked(new RoleRevoked(
+            AssignmentId: assignment.Id,
+            SubjectId: subject.Id,
+            SubjectExternalId: subject.ExternalId,
+            RoleId: role.Id,
+            RoleCode: role.Code,
+            ResourceInstanceId: resourceInstanceId,
+            OccurredAt: DateTimeOffset.UtcNow));
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation("Revoked role {RoleCode} from {SubjectId}", roleCode, subjectExternalId);

--- a/src/Andy.Rbac.Infrastructure/Andy.Rbac.Infrastructure.csproj
+++ b/src/Andy.Rbac.Infrastructure/Andy.Rbac.Infrastructure.csproj
@@ -15,6 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="NATS.Client.Core" />
+    <PackageReference Include="NATS.Client.JetStream" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 

--- a/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508005828_AddOutboxTable.Designer.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508005828_AddOutboxTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Rbac.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Rbac.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(RbacDbContext))]
-    partial class RbacDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508005828_AddOutboxTable")]
+    partial class AddOutboxTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508005828_AddOutboxTable.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508005828_AddOutboxTable.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Rbac.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "outbox",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Subject = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    PayloadType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    PayloadJson = table.Column<string>(type: "text", nullable: false),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CausationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Generation = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    PublishedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    AttemptCount = table.Column<int>(type: "integer", nullable: false),
+                    LastAttemptAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_outbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_outbox_CorrelationId",
+                table: "outbox",
+                column: "CorrelationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_outbox_CreatedAt",
+                table: "outbox",
+                column: "CreatedAt",
+                filter: "\"PublishedAt\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "outbox");
+        }
+    }
+}

--- a/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Andy.Rbac.Messaging;
 using Andy.Rbac.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -29,6 +30,11 @@ public class RbacDbContext : DbContext
     public DbSet<TeamMember> TeamMembers => Set<TeamMember>();
     public DbSet<TeamRole> TeamRoles => Set<TeamRole>();
     public DbSet<ApiKey> ApiKeys => Set<ApiKey>();
+
+    // AL2: transactional outbox. Domain writes that need to emit cross-
+    // service events (RoleService, future PolicyService) append rows here
+    // inside the same transaction; OutboxDispatcher drains them to NATS.
+    public DbSet<OutboxEntry> Outbox => Set<OutboxEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -350,6 +356,34 @@ public class RbacDbContext : DbContext
                 .WithMany()
                 .HasForeignKey(e => e.ApplicationId)
                 .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // OutboxEntry (AL2). Stored as plain text columns for provider
+        // portability — Postgres jsonb buys nothing here since the
+        // dispatcher round-trips strings to NATS.
+        modelBuilder.Entity<OutboxEntry>(entity =>
+        {
+            entity.ToTable("outbox");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Subject).HasMaxLength(256).IsRequired();
+            entity.Property(e => e.PayloadType).HasMaxLength(256);
+            entity.Property(e => e.PayloadJson).IsRequired();
+            entity.Property(e => e.LastError).HasMaxLength(2000);
+            entity.HasIndex(e => e.CorrelationId);
+
+            // Partial index on pending rows so the dispatcher's hot query
+            // (WHERE PublishedAt IS NULL ORDER BY CreatedAt) scans only
+            // the pending working set rather than the full audit history.
+            // Postgres-only — SQLite / InMemory get a non-filtered index.
+            if (Database.IsNpgsql())
+            {
+                entity.HasIndex(e => e.CreatedAt)
+                    .HasFilter("\"PublishedAt\" IS NULL");
+            }
+            else
+            {
+                entity.HasIndex(e => e.CreatedAt);
+            }
         });
     }
 }

--- a/src/Andy.Rbac.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Channels;
+using Andy.Rbac.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// In-process IMessageBus implementation. Used in tests and as the default
+// development provider until NATS wire-up lands (m3/m4). Supports NATS
+// subject wildcards: '*' matches one token, '>' matches one or more
+// trailing tokens.
+//
+// This is deliberately not a drop-in production replacement for NATS.
+// It has no durability (messages vanish on process restart), no
+// cross-process delivery, and no back-pressure beyond channel capacity.
+// But it faithfully implements the IMessageBus contract for loopback
+// testing, which proves the outbox + dispatcher + bus wiring before
+// the real NATS client arrives.
+//
+// Runtime cycle breaker (per ADR 0001): PublishAsync drops messages
+// whose Headers.ExceedsGenerationLimit is true, logs at Error with the
+// causation chain, and returns. The drop happens before any subscriber
+// is notified.
+public sealed class InMemoryMessageBus : IMessageBus
+{
+    private readonly ILogger<InMemoryMessageBus> _logger;
+
+    // One unbounded channel per active subscription. Keyed by the
+    // exact subject filter the subscriber passed, so two subscribers
+    // with different filters each get their own channel and fan-out
+    // happens naturally in PublishAsync.
+    private readonly ConcurrentDictionary<string, Channel<IncomingMessage>> _subscriptions = new();
+
+    public InMemoryMessageBus(ILogger<InMemoryMessageBus> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default)
+    {
+        if (headers.ExceedsGenerationLimit)
+        {
+            _logger.LogError(
+                "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                "Correlation: {CorrId} Causation: {CausedBy}",
+                headers.MsgId, subject, headers.Generation, MessageHeaders.MaxGeneration,
+                headers.CorrelationId, headers.CausationId);
+            return Task.CompletedTask;
+        }
+
+        // Use the same snake_case naming policy NatsMessageBus uses
+        // (and that every consumer's IncomingMessage.Deserialize<T>
+        // assumes by default). Without EventJson.Options here, a
+        // typed record passed to PublishAsync would serialize
+        // PascalCase ("IssueId") while the consumer expects
+        // snake_case ("issue_id"), and fields would silently bind to
+        // defaults. JsonElement payloads (the OutboxDispatcher path)
+        // already carry pre-serialized tokens, so JsonSerializer
+        // emits them as-is regardless of naming policy.
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, EventJson.Options);
+
+        foreach (var (filter, channel) in _subscriptions)
+        {
+            if (!MatchesSubject(filter, subject))
+            {
+                continue;
+            }
+
+            var message = new InMemoryIncomingMessage
+            {
+                Headers = headers,
+                Subject = subject,
+                Payload = bytes,
+                ReceivedAt = DateTimeOffset.UtcNow
+            };
+
+            // Unbounded channel: TryWrite always succeeds until cancellation.
+            channel.Writer.TryWrite(message);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // Pre-register the channel for a subject filter. Exposed so tests can
+    // avoid the race between "start subscriber task" and "publish first
+    // message" — calling this before publishing guarantees the channel
+    // exists. Production consumers don't need to call it; SubscribeAsync
+    // uses the same GetOrAdd internally.
+    internal Channel<IncomingMessage> EnsureChannel(string subjectFilter)
+    {
+        return _subscriptions.GetOrAdd(
+            subjectFilter,
+            _ => Channel.CreateUnbounded<IncomingMessage>(new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = false
+            }));
+    }
+
+    public async IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var channel = EnsureChannel(subjectFilter);
+
+        _logger.LogDebug("Subscription opened on {Filter} durable {Durable}",
+            subjectFilter, options.DurableName);
+
+        try
+        {
+            await foreach (var message in channel.Reader.ReadAllAsync(ct))
+            {
+                yield return message;
+            }
+        }
+        finally
+        {
+            // Best-effort cleanup. If multiple subscribers share a filter
+            // this will remove the channel on the first unsubscribe, but
+            // that is acceptable for an in-memory test bus.
+            _subscriptions.TryRemove(subjectFilter, out _);
+            _logger.LogDebug("Subscription closed on {Filter}", subjectFilter);
+        }
+    }
+
+    // NATS subject match semantics:
+    //   '*' matches exactly one token
+    //   '>' matches one or more trailing tokens (must be the last token
+    //       in the filter)
+    internal static bool MatchesSubject(string filter, string subject)
+    {
+        if (filter == subject)
+        {
+            return true;
+        }
+
+        var filterTokens = filter.Split('.');
+        var subjectTokens = subject.Split('.');
+
+        for (int i = 0; i < filterTokens.Length; i++)
+        {
+            if (filterTokens[i] == ">")
+            {
+                // '>' is only valid as the last token and must consume
+                // at least one remaining subject token.
+                return i == filterTokens.Length - 1 && i < subjectTokens.Length;
+            }
+
+            if (i >= subjectTokens.Length)
+            {
+                return false;
+            }
+
+            if (filterTokens[i] != "*" && filterTokens[i] != subjectTokens[i])
+            {
+                return false;
+            }
+        }
+
+        // Exhausted the filter: match only if we also exhausted the subject.
+        return filterTokens.Length == subjectTokens.Length;
+    }
+}
+
+// Trivial IncomingMessage wrapper for the in-memory bus. Ack and Nack
+// are no-ops because the in-memory bus has no durable offset to advance.
+internal sealed class InMemoryIncomingMessage : IncomingMessage
+{
+    public override Task AckAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public override Task NackAsync(CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/NatsMessageBus.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/NatsMessageBus.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Andy.Rbac.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// IMessageBus backed by NATS JetStream per ADR 0001. The connection is
+// created once at construction and disposed when the DI container shuts
+// down. Stream provisioning (CreateOrUpdateStream) is handled by the
+// separate NatsStreamProvisioner hosted service which runs before any
+// BackgroundService, guaranteeing the stream exists before the
+// OutboxDispatcher or GoalCreatedHandler start publishing/subscribing.
+public sealed class NatsMessageBus : IMessageBus, IAsyncDisposable
+{
+    // AK6: meter name registered in Program.cs OTel pipeline so the
+    // generation-breach counter is exported via OTLP.
+    public const string MeterName = "Andy.Rbac.Messaging";
+    private const string ServiceTag = "andy-tasks";
+
+    private static readonly Meter _meter = new(MeterName);
+    private static readonly Counter<long> _generationBreachCounter =
+        _meter.CreateCounter<long>(
+            name: "rivoli_nats_generation_limit_breach_total",
+            unit: "{breach}",
+            description: "Cumulative count of messages whose generation exceeded the ADR-0001 limit (drop on publish, DLQ on consume).");
+
+    private readonly NatsOptions _options;
+    private readonly ILogger<NatsMessageBus> _logger;
+    private readonly NatsConnection _connection;
+    private readonly INatsJSContext _jsContext;
+
+    public NatsMessageBus(IOptions<NatsOptions> options, ILogger<NatsMessageBus> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _connection = new NatsConnection(new NatsOpts { Url = _options.Url });
+        _jsContext = new NatsJSContext(_connection);
+    }
+
+    internal INatsJSContext JetStream => _jsContext;
+    internal NatsConnection Connection => _connection;
+
+    // Eagerly connect the underlying TCP socket. Called by
+    // NatsStreamProvisioner.StartAsync before any publish/subscribe
+    // so we don't pay the lazy-connect cost on the first hot-path
+    // operation.
+    internal async Task ConnectAsync(CancellationToken ct = default)
+    {
+        await _connection.ConnectAsync();
+    }
+
+    public async Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default)
+    {
+        if (headers.ExceedsGenerationLimit)
+        {
+            _logger.LogError(
+                "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                "Correlation: {CorrId} Causation: {CausedBy}",
+                headers.MsgId, subject, headers.Generation, MessageHeaders.MaxGeneration,
+                headers.CorrelationId, headers.CausationId);
+            RecordGenerationBreach(direction: "publish", subject);
+            return;
+        }
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, EventJson.Options);
+        var natsHeaders = ToNatsHeaders(headers);
+
+        var ack = await _jsContext.PublishAsync(subject, bytes, headers: natsHeaders, cancellationToken: ct);
+
+        if (ack.Error is not null)
+        {
+            throw new InvalidOperationException(
+                $"NATS JetStream publish rejected on {subject}: {ack.Error.Code} {ack.Error.Description}");
+        }
+    }
+
+    public async IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // NATS 2.10+ embeds the consumer name in the subject for the
+        // CREATE API ($JS.API.CONSUMER.CREATE.<stream>.<name>). Dots in
+        // the name break subject parsing. Sanitize to dashes.
+        var safeDurableName = options.DurableName.Replace('.', '-');
+
+        var consumerConfig = new ConsumerConfig(safeDurableName)
+        {
+            FilterSubject = options.SubjectFilter ?? subjectFilter,
+            AckPolicy = options.ManualAck
+                ? ConsumerConfigAckPolicy.Explicit
+                : ConsumerConfigAckPolicy.None,
+            MaxDeliver = options.MaxDeliver
+        };
+
+        // AK5: with two streams (ANDY_PROGRESS / ANDY_DOMAIN) we resolve
+        // the owning stream by client-side subject-pattern matching. NATS
+        // routes publishes by subject, but the consumer-create API needs
+        // the explicit stream name.
+        var streamName = ResolveStreamName(consumerConfig.FilterSubject ?? subjectFilter);
+
+        var consumer = await _jsContext.CreateOrUpdateConsumerAsync(
+            streamName, consumerConfig, ct);
+
+        _logger.LogDebug(
+            "Subscription opened on {Filter} durable {Durable}",
+            subjectFilter, options.DurableName);
+
+        await foreach (var jsMsg in consumer.ConsumeAsync<byte[]>(cancellationToken: ct))
+        {
+            var parsed = TryParseHeaders(jsMsg);
+            if (parsed is null)
+            {
+                _logger.LogWarning(
+                    "Dropping message on {Subject} — missing or malformed required headers. " +
+                    "Acking to prevent redelivery loop",
+                    jsMsg.Subject);
+                await PublishToDlqAsync(jsMsg.Subject, jsMsg.Data, jsMsg.Headers, ct);
+                await jsMsg.AckAsync(cancellationToken: ct);
+                continue;
+            }
+
+            if (parsed.ExceedsGenerationLimit)
+            {
+                _logger.LogError(
+                    "Dropping message {MsgId} on {Subject} — generation {Gen} exceeds limit {Max}. " +
+                    "Correlation: {CorrId} Causation: {CausedBy}",
+                    parsed.MsgId, jsMsg.Subject, parsed.Generation, MessageHeaders.MaxGeneration,
+                    parsed.CorrelationId, parsed.CausationId);
+                RecordGenerationBreach(direction: "consume", jsMsg.Subject);
+                await PublishToDlqAsync(jsMsg.Subject, jsMsg.Data, jsMsg.Headers, ct);
+                await jsMsg.AckAsync(cancellationToken: ct);
+                continue;
+            }
+
+            yield return new NatsIncomingMessage(jsMsg)
+            {
+                Headers = parsed,
+                Subject = jsMsg.Subject,
+                Payload = jsMsg.Data ?? ReadOnlyMemory<byte>.Empty,
+                ReceivedAt = DateTimeOffset.UtcNow
+            };
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+    }
+
+    private static NatsHeaders ToNatsHeaders(MessageHeaders headers)
+    {
+        return new NatsHeaders
+        {
+            { "Nats-Msg-Id", headers.MsgId.ToString() },
+            { "Andy-Correlation-Id", headers.CorrelationId.ToString() },
+            { "Andy-Causation-Id", headers.CausationId?.ToString() ?? "" },
+            { "Andy-Generation", headers.Generation.ToString() }
+        };
+    }
+
+    private static MessageHeaders? TryParseHeaders(INatsJSMsg<byte[]> jsMsg)
+    {
+        if (jsMsg.Headers is null)
+            return null;
+
+        var h = jsMsg.Headers;
+
+        if (!h.TryGetValue("Nats-Msg-Id", out var msgIdValues)
+            || !Guid.TryParse(msgIdValues.ToString(), out var msgId))
+            return null;
+
+        if (!h.TryGetValue("Andy-Correlation-Id", out var corrValues)
+            || !Guid.TryParse(corrValues.ToString(), out var correlationId))
+            return null;
+
+        if (!h.TryGetValue("Andy-Generation", out var genValues)
+            || !int.TryParse(genValues.ToString(), out var generation))
+            return null;
+
+        Guid? causationId = null;
+        if (h.TryGetValue("Andy-Causation-Id", out var causValues))
+        {
+            var raw = causValues.ToString();
+            if (!string.IsNullOrEmpty(raw) && Guid.TryParse(raw, out var parsed))
+                causationId = parsed;
+        }
+
+        return new MessageHeaders(msgId, correlationId, causationId, generation);
+    }
+
+    private static void RecordGenerationBreach(string direction, string subject)
+    {
+        _generationBreachCounter.Add(1,
+            new KeyValuePair<string, object?>("service", ServiceTag),
+            new KeyValuePair<string, object?>("direction", direction),
+            new KeyValuePair<string, object?>("subject_root", TruncateSubjectRoot(subject)));
+    }
+
+    // Keep at most the first three dot-segments so a runaway breach storm
+    // can't explode metric cardinality through the {id} segment.
+    internal static string TruncateSubjectRoot(string subject)
+    {
+        if (string.IsNullOrEmpty(subject))
+            return string.Empty;
+
+        var firstDot = subject.IndexOf('.');
+        if (firstDot < 0) return subject;
+        var secondDot = subject.IndexOf('.', firstDot + 1);
+        if (secondDot < 0) return subject;
+        var thirdDot = subject.IndexOf('.', secondDot + 1);
+        return thirdDot < 0 ? subject : subject[..thirdDot];
+    }
+
+    private string ResolveStreamName(string subscribeFilter)
+    {
+        foreach (var stream in _options.Streams)
+        {
+            foreach (var streamSubject in stream.Subjects)
+            {
+                if (StreamSubjectCovers(streamSubject, subscribeFilter))
+                    return stream.Name;
+            }
+        }
+        throw new InvalidOperationException(
+            $"No configured Messaging:Nats:Streams entry covers subscribe filter '{subscribeFilter}'.");
+    }
+
+    // True iff every concrete subject the subscribe filter could match
+    // is also matched by streamSubject (i.e. streamSubject is at least
+    // as permissive as subscribeFilter, token-by-token, with NATS '*'
+    // and '>' semantics).
+    internal static bool StreamSubjectCovers(string streamSubject, string subscribeFilter)
+    {
+        var streamTokens = streamSubject.Split('.');
+        var filterTokens = subscribeFilter.Split('.');
+
+        for (var i = 0; i < streamTokens.Length; i++)
+        {
+            var s = streamTokens[i];
+            if (s == ">")
+                return i <= filterTokens.Length;
+            if (i >= filterTokens.Length)
+                return false;
+            if (s == "*")
+                continue;
+            if (s != filterTokens[i])
+                return false;
+        }
+        return streamTokens.Length == filterTokens.Length;
+    }
+
+    private async Task PublishToDlqAsync(
+        string originalSubject,
+        byte[]? payload,
+        NatsHeaders? originalHeaders,
+        CancellationToken ct)
+    {
+        try
+        {
+            var dlqSubject = $"{_options.DlqPrefix}.{originalSubject}";
+            await _jsContext.PublishAsync(
+                dlqSubject,
+                payload ?? [],
+                headers: originalHeaders,
+                cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to publish to DLQ for {OriginalSubject} — message is lost",
+                originalSubject);
+        }
+    }
+}
+
+// Wraps an INatsJSMsg<byte[]> so consumers call Ack/Nack through the
+// IncomingMessage abstraction without knowing about the NATS client.
+internal sealed class NatsIncomingMessage : IncomingMessage
+{
+    private readonly INatsJSMsg<byte[]> _jsMsg;
+
+    internal NatsIncomingMessage(INatsJSMsg<byte[]> jsMsg)
+    {
+        _jsMsg = jsMsg;
+    }
+
+    public override async Task AckAsync(CancellationToken ct = default)
+    {
+        await _jsMsg.AckAsync(cancellationToken: ct);
+    }
+
+    public override async Task NackAsync(CancellationToken ct = default)
+    {
+        await _jsMsg.NakAsync(cancellationToken: ct);
+    }
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/NatsOptions.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/NatsOptions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+public sealed class NatsOptions
+{
+    public const string SectionName = "Messaging:Nats";
+
+    public string Url { get; set; } = "nats://localhost:4222";
+
+    // ADR-0001 §"Resolved decisions" #1 (AK5): retention is split by class.
+    // Two streams are provisioned by NatsStreamProvisioner:
+    //   ANDY_PROGRESS — short-lived run/container progress events (7 days).
+    //   ANDY_DOMAIN   — long-lived goal/task/issue/agents events + DLQs (90 days).
+    // Production wiring binds this from appsettings.json. Default left empty
+    // because IConfiguration.Bind APPENDS to existing array properties — a
+    // non-empty default would produce duplicates after bind. Tests / callers
+    // that don't bind a config section can use DefaultStreams() explicitly.
+    public NatsStreamSpec[] Streams { get; set; } = [];
+
+    public string DlqPrefix { get; set; } = "andy.rbac.dlq";
+
+    // andy-rbac is a publisher only (Epic AL — AL3 subject scheme + AL4
+    // emission). One long-retention stream covers both event + DLQ
+    // subjects scoped to the andy.rbac.* namespace.
+    public static NatsStreamSpec[] DefaultStreams() =>
+    [
+        new NatsStreamSpec
+        {
+            Name = "ANDY_RBAC",
+            Subjects =
+            [
+                "andy.rbac.events.>",
+                "andy.rbac.dlq.>"
+            ],
+            MaxAge = TimeSpan.FromDays(90)
+        }
+    ];
+}
+
+public sealed class NatsStreamSpec
+{
+    public string Name { get; set; } = "";
+    public string[] Subjects { get; set; } = [];
+    public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(7);
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/NatsStreamProvisioner.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/NatsStreamProvisioner.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NATS.Client.JetStream.Models;
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// Ensures the JetStream streams exist before any BackgroundService
+// (OutboxDispatcher, GoalCreatedHandler) starts publishing or
+// subscribing. IHostedService.StartAsync runs before BackgroundService
+// .ExecuteAsync, so the ordering guarantee is built into the host.
+// CreateOrUpdateStreamAsync is idempotent — safe on every boot.
+public sealed class NatsStreamProvisioner(
+    NatsMessageBus bus,
+    IOptions<NatsOptions> options,
+    ILogger<NatsStreamProvisioner> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken ct)
+    {
+        await bus.ConnectAsync(ct);
+
+        var opts = options.Value;
+        if (opts.Streams.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "Messaging:Nats:Streams is empty. At least one stream must be configured.");
+        }
+
+        foreach (var spec in opts.Streams)
+        {
+            var config = new StreamConfig(spec.Name, spec.Subjects)
+            {
+                MaxAge = spec.MaxAge
+            };
+
+            await bus.JetStream.CreateOrUpdateStreamAsync(config, ct);
+
+            // AK5: log retention so an operator inspecting boot logs can
+            // confirm the active window without querying NATS directly.
+            logger.LogInformation(
+                "NATS JetStream stream {Stream} provisioned with subjects [{Subjects}], retention {Retention}",
+                spec.Name, string.Join(", ", spec.Subjects), spec.MaxAge);
+        }
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/OutboxDispatcher.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/OutboxDispatcher.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Rbac.Messaging;
+using Andy.Rbac.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// Background worker that drains the OutboxEntry table to the message bus.
+// One instance per service. Polls at a configurable interval, batches
+// pending rows, publishes each to its target subject, records success
+// or failure. Rows are never deleted — the outbox doubles as an audit
+// log. A separate retention policy may purge published rows older than
+// N days.
+//
+// Retry semantics: on publish failure the row stays pending with
+// AttemptCount incremented and LastError set. The dispatcher respects
+// an exponential-backoff delay between retries based on AttemptCount
+// so a poison message does not spin the worker at full speed. After
+// MaxAttempts the row is marked as dead and logged; operator action
+// required. (MaxAttempts is not yet enforced in this stub — noted as
+// a follow-up.)
+//
+// This is currently a scaffold. The core drain loop is wired but
+// PublishAsync delegates to NatsMessageBus which is itself a stub —
+// so the worker will log and throw. The Program.cs wiring lands in
+// a follow-up commit along with the real NATS client.
+public sealed class OutboxDispatcher : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OutboxDispatcher> _logger;
+    private readonly TimeSpan _pollInterval;
+    private readonly int _batchSize;
+
+    public OutboxDispatcher(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OutboxDispatcher> logger,
+        IOptions<OutboxDispatcherOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _pollInterval = options.Value.PollInterval;
+        _batchSize = options.Value.BatchSize;
+
+        // AK2: ADR-0001 op invariant — PollInterval ≤ 2s across services.
+        if (_pollInterval > OutboxDispatcherOptions.MaxRecommendedPollInterval)
+        {
+            _logger.LogWarning(
+                "OutboxDispatcher Messaging:Outbox:PollInterval {Interval} exceeds the recommended maximum {Max}. " +
+                "Outbound publish latency will be at least one poll interval; values above 2s violate ADR-0001 operational invariants.",
+                _pollInterval, OutboxDispatcherOptions.MaxRecommendedPollInterval);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("OutboxDispatcher started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var drained = await DrainOnceAsync(stoppingToken);
+                if (drained == 0)
+                {
+                    await Task.Delay(_pollInterval, stoppingToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "OutboxDispatcher tick failed; backing off");
+                await Task.Delay(_pollInterval, stoppingToken);
+            }
+        }
+
+        _logger.LogInformation("OutboxDispatcher stopped");
+    }
+
+    internal async Task<int> DrainOnceAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RbacDbContext>();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        var pending = await db.Set<OutboxEntry>()
+            .Where(e => e.PublishedAt == null)
+            .OrderBy(e => e.CreatedAt)
+            .Take(_batchSize)
+            .ToListAsync(ct);
+
+        if (pending.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var entry in pending)
+        {
+            try
+            {
+                var headers = new MessageHeaders(
+                    MsgId: entry.Id,
+                    CorrelationId: entry.CorrelationId,
+                    CausationId: entry.CausationId,
+                    Generation: entry.Generation);
+
+                // Payload is stored as JSON text, but IMessageBus.PublishAsync
+                // expects an object (it re-serializes). For the stub we pass
+                // a JsonDocument so the bus has something to serialize back.
+                // The real implementation will take a raw-bytes overload to
+                // avoid the round trip.
+                using var doc = JsonDocument.Parse(entry.PayloadJson);
+                await bus.PublishAsync(entry.Subject, doc.RootElement, headers, ct);
+
+                entry.PublishedAt = DateTimeOffset.UtcNow;
+                entry.LastError = null;
+            }
+            catch (Exception ex)
+            {
+                entry.AttemptCount++;
+                entry.LastAttemptAt = DateTimeOffset.UtcNow;
+                entry.LastError = ex.Message;
+                _logger.LogWarning(ex,
+                    "Outbox entry {EntryId} publish failed (attempt {Attempt})",
+                    entry.Id, entry.AttemptCount);
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return pending.Count;
+    }
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/OutboxDispatcherOptions.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/OutboxDispatcherOptions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// Knobs for the OutboxDispatcher background worker. Bound from the
+// "Messaging:Outbox" configuration section by Program.cs. Integration
+// tests override PollInterval down to ~50ms so the end-to-end loops
+// finish in tens of milliseconds instead of seconds.
+public sealed class OutboxDispatcherOptions
+{
+    public const string SectionName = "Messaging:Outbox";
+
+    // ADR-0001 operational invariant (AK2): PollInterval ≤ 2s across all
+    // services on the bus. Exceeding this triggers a startup warning;
+    // CI asserts appsettings.json conforms.
+    public static readonly TimeSpan MaxRecommendedPollInterval = TimeSpan.FromSeconds(2);
+
+    // Delay between drains when the outbox is empty. When a drain
+    // finds rows, the worker loops immediately to keep up with a
+    // burst; only the empty-poll path sleeps.
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    // Max rows per drain. Bounds the transaction size and the
+    // failure blast-radius of a poison message.
+    public int BatchSize { get; set; } = 100;
+}

--- a/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Messaging;
+using Andy.Rbac.Messaging.Events;
+
+namespace Andy.Rbac.Infrastructure.Messaging;
+
+// AL2 + AL3 + AL4: stages outbox rows on the shared RbacDbContext. The
+// caller's SaveChangesAsync commits the domain row + the outbox row in
+// a single transaction; the OutboxDispatcher later drains the row to
+// NATS with at-least-once delivery semantics.
+public sealed class RbacEventPublisher : IRbacEventPublisher
+{
+    private const string SubjectPrefix = "andy.rbac.events";
+
+    private readonly RbacDbContext _db;
+
+    public RbacEventPublisher(RbacDbContext db)
+    {
+        _db = db;
+    }
+
+    public void RoleCreated(RoleCreated payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.role.{payload.RoleId}.created", payload, headers);
+
+    public void RoleUpdated(RoleUpdated payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.role.{payload.RoleId}.updated", payload, headers);
+
+    public void RoleDeleted(RoleDeleted payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.role.{payload.RoleId}.deleted", payload, headers);
+
+    public void RoleAssigned(RoleAssigned payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.subject_role.{payload.AssignmentId}.granted", payload, headers);
+
+    public void RoleRevoked(RoleRevoked payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.subject_role.{payload.AssignmentId}.revoked", payload, headers);
+
+    public void PolicyCreated(PolicyCreated payload, MessageHeaders? headers = null)
+        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+
+    public void PolicyUpdated(PolicyUpdated payload, MessageHeaders? headers = null)
+        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+
+    public void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null)
+        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+
+    private void Stage(string subject, object payload, MessageHeaders? headers)
+    {
+        headers ??= MessageHeaders.NewRoot();
+        if (headers.ExceedsGenerationLimit)
+        {
+            // Defense-in-depth — should be unreachable since rbac is publisher-
+            // only and starts every chain at generation 0. If we ever wire
+            // event-driven reactions in rbac itself, this guard prevents a
+            // runaway cycle from leaking onto the bus.
+            return;
+        }
+
+        var json = JsonSerializer.Serialize(payload, payload.GetType(), EventJson.Options);
+
+        _db.Outbox.Add(new OutboxEntry
+        {
+            Id = headers.MsgId,
+            Subject = subject,
+            PayloadType = payload.GetType().FullName,
+            PayloadJson = json,
+            CorrelationId = headers.CorrelationId,
+            CausationId = headers.CausationId,
+            Generation = headers.Generation,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+    }
+}

--- a/src/Andy.Rbac/Messaging/EventJson.cs
+++ b/src/Andy.Rbac/Messaging/EventJson.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Rbac.Messaging;
+
+// Canonical JSON options for every ADR 0001 event payload. Producers
+// (GoalService, future task/run services) serialize outbox rows with
+// these options; consumers (IncomingMessage.Deserialize) decode with
+// the same. Centralizing them here is the difference between "works
+// by coincidence" and "works by contract" — without it, a publisher
+// using snake_case and a consumer using default camelCase silently
+// deserialize to default-valued fields.
+//
+// Snake case is picked to match the convention already used by
+// RbacDbContext's JSON-backed columns and the Andy ecosystem's wire
+// format broadly. Strings for enums so consumers don't depend on
+// ordinal stability when a new enum member lands.
+public static class EventJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DictionaryKeyPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
+++ b/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Messaging.Events;
+
+// AL4 Policy lifecycle events — STUB. Epic V (Policy entity + service)
+// shipped as the design doc only; the runtime entity has not landed on
+// main yet. These types and their subject scheme are reserved here so
+// that downstream consumers (andy-docs RetentionCascadeWorker, future
+// PDP cache invalidation) can pin against a stable wire contract while
+// the entity work catches up. The publisher exposes Policy.* helpers
+// that throw NotImplementedException — wiring them to a real entity is
+// a one-line change once Epic V lands.
+//
+// Subject scheme (AL3): andy.rbac.events.policy.{policy_id}.{kind}
+
+public sealed record PolicyCreated(
+    Guid PolicyId,
+    string Code,
+    string? ApplicationCode,
+    DateTimeOffset OccurredAt
+);
+
+public sealed record PolicyUpdated(
+    Guid PolicyId,
+    string Code,
+    string? ApplicationCode,
+    DateTimeOffset OccurredAt
+);
+
+public sealed record PolicyDeleted(
+    Guid PolicyId,
+    string Code,
+    string? ApplicationCode,
+    DateTimeOffset OccurredAt
+);

--- a/src/Andy.Rbac/Messaging/Events/RoleEvents.cs
+++ b/src/Andy.Rbac/Messaging/Events/RoleEvents.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Messaging.Events;
+
+// AL4 Role lifecycle events. Subject scheme (AL3):
+//   andy.rbac.events.role.{role_id}.{kind}
+//
+// Consumers (andy-tasks AD4a, future andy-docs RetentionCascadeWorker)
+// subscribe to andy.rbac.events.role.> with a durable consumer and
+// project role membership / permission deltas into their own caches.
+
+public sealed record RoleCreated(
+    Guid RoleId,
+    string Code,
+    string Name,
+    string? ApplicationCode,
+    string? ParentRoleCode,
+    bool IsSystem,
+    DateTimeOffset OccurredAt
+);
+
+public sealed record RoleUpdated(
+    Guid RoleId,
+    string Code,
+    string Name,
+    string? ApplicationCode,
+    DateTimeOffset OccurredAt
+);
+
+public sealed record RoleDeleted(
+    Guid RoleId,
+    string Code,
+    string? ApplicationCode,
+    DateTimeOffset OccurredAt
+);
+
+// Per-subject role grant/revoke. Subject scheme:
+//   andy.rbac.events.subject_role.{assignment_id}.{kind}
+
+public sealed record RoleAssigned(
+    Guid AssignmentId,
+    Guid SubjectId,
+    string SubjectExternalId,
+    Guid RoleId,
+    string RoleCode,
+    string? ResourceInstanceId,
+    DateTimeOffset OccurredAt
+);
+
+public sealed record RoleRevoked(
+    Guid AssignmentId,
+    Guid SubjectId,
+    string SubjectExternalId,
+    Guid RoleId,
+    string RoleCode,
+    string? ResourceInstanceId,
+    DateTimeOffset OccurredAt
+);

--- a/src/Andy.Rbac/Messaging/IMessageBus.cs
+++ b/src/Andy.Rbac/Messaging/IMessageBus.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+
+namespace Andy.Rbac.Messaging;
+
+// Cross-service messaging abstraction. Implementations publish to a bus
+// (default: NATS JetStream per ADR 0001) and yield incoming messages from
+// durable subscriptions.
+//
+// This interface is deliberately small. Publish serializes the payload to
+// JSON bytes internally; Subscribe yields raw IncomingMessage instances and
+// consumers call Deserialize<T> to decode. Subject convention and causation
+// rules are enforced by callers, not by the bus — the bus is a transport.
+public interface IMessageBus
+{
+    // Publish a single message. The bus is responsible for serializing
+    // payload to JSON and attaching headers. Callers should not call this
+    // directly; prefer writing to the OutboxEntry table inside the same
+    // transaction as the domain change, and let the OutboxDispatcher drain
+    // it. Direct publish is permitted only for ephemeral messages that do
+    // not need at-least-once delivery (e.g. system.health heartbeats).
+    Task PublishAsync(
+        string subject,
+        object payload,
+        MessageHeaders headers,
+        CancellationToken ct = default);
+
+    // Create a durable subscription. The stream yields incoming messages
+    // until cancellation or until the bus terminates. Consumers are expected
+    // to call Ack/Nack on each IncomingMessage before taking the next.
+    // Generation overflow (> MessageHeaders.MaxGeneration) is handled by the
+    // bus: offending messages are dropped before reaching the consumer, with
+    // an error-level log that includes the full causation chain.
+    IAsyncEnumerable<IncomingMessage> SubscribeAsync(
+        string subjectFilter,
+        SubscriptionOptions options,
+        CancellationToken ct = default);
+}
+
+// Four-field header envelope required on every message per ADR 0001.
+public sealed record MessageHeaders(
+    Guid MsgId,
+    Guid CorrelationId,
+    Guid? CausationId,
+    int Generation
+)
+{
+    // Hop limit from ADR 0001. Messages exceeding this generation count
+    // are dropped by the bus as a runtime circuit breaker for cycles.
+    public const int MaxGeneration = 10;
+
+    // Start a new causation chain. Use for messages triggered directly by
+    // user input or by a scheduled worker tick — anything not produced in
+    // response to an incoming message.
+    public static MessageHeaders NewRoot(Guid? correlationId = null)
+    {
+        var id = Guid.NewGuid();
+        return new MessageHeaders(
+            MsgId: id,
+            CorrelationId: correlationId ?? id,
+            CausationId: null,
+            Generation: 0);
+    }
+
+    // Continue an existing causation chain. Use when emitting a message
+    // in response to an incoming message from another service.
+    public static MessageHeaders Follow(MessageHeaders parent)
+    {
+        return new MessageHeaders(
+            MsgId: Guid.NewGuid(),
+            CorrelationId: parent.CorrelationId,
+            CausationId: parent.MsgId,
+            Generation: parent.Generation + 1);
+    }
+
+    public bool ExceedsGenerationLimit => Generation > MaxGeneration;
+}
+
+// Abstract incoming-message wrapper. Concrete implementations (e.g.
+// NatsIncomingMessage) attach the provider-specific ack/nack mechanism.
+public abstract class IncomingMessage
+{
+    public required MessageHeaders Headers { get; init; }
+    public required string Subject { get; init; }
+    public required ReadOnlyMemory<byte> Payload { get; init; }
+    public required DateTimeOffset ReceivedAt { get; init; }
+
+    // Decode the payload as the given type. Returns null if the payload
+    // is empty. Callers are responsible for knowing the expected type
+    // based on the subscription's subject filter. Defaults to the
+    // canonical ADR 0001 wire options (EventJson.Options) so producers
+    // and consumers don't need to negotiate snake-case / camelCase out
+    // of band — pass an explicit options to override.
+    public T? Deserialize<T>(JsonSerializerOptions? options = null) where T : class
+    {
+        if (Payload.IsEmpty) return null;
+        return JsonSerializer.Deserialize<T>(Payload.Span, options ?? EventJson.Options);
+    }
+
+    // Acknowledge successful processing. The bus advances its durable
+    // consumer offset and will not redeliver this message.
+    public abstract Task AckAsync(CancellationToken ct = default);
+
+    // Negative-acknowledge. The bus will redeliver according to its
+    // retry policy up to SubscriptionOptions.MaxDeliver attempts, then
+    // move the message to the dead-letter subject.
+    public abstract Task NackAsync(CancellationToken ct = default);
+}
+
+public sealed record SubscriptionOptions(
+    // Durable consumer name. Required for JetStream subscriptions so
+    // consumer offsets survive restarts. Must be stable across service
+    // restarts — typically "<service-name>.<purpose>" e.g.
+    // "andy-tasks.container-events".
+    string DurableName,
+
+    // Maximum delivery attempts before moving to the dead-letter
+    // subject. Default 10 per ADR 0001 open question #3 — revisit.
+    int MaxDeliver = 10,
+
+    // Whether the consumer must explicitly Ack/Nack each message.
+    // When false, the bus auto-acks on delivery (at-most-once).
+    // Default true for durable consumers.
+    bool ManualAck = true,
+
+    // Optional filter for a narrower subject within the subscription's
+    // base filter. Useful for splitting one subscription into multiple
+    // handlers without creating multiple durable consumers.
+    string? SubjectFilter = null
+);

--- a/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
+++ b/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Rbac.Messaging.Events;
+
+namespace Andy.Rbac.Messaging;
+
+// AL3 + AL4 publisher facade for the rbac service. Callers (RoleService,
+// future PolicyService) invoke the typed helpers below; the implementation
+// stages an OutboxEntry on the DbContext but does NOT call SaveChangesAsync —
+// the caller's existing SaveChanges commits both the domain row and the
+// outbox row in a single transaction (transactional outbox pattern, AL2).
+//
+// Subject scheme (ADR 0001 + AL3):
+//   andy.rbac.events.role.{role_id}.{created|updated|deleted}
+//   andy.rbac.events.subject_role.{assignment_id}.{granted|revoked}
+//   andy.rbac.events.policy.{policy_id}.{created|updated|deleted}    (stub — Epic V pending)
+public interface IRbacEventPublisher
+{
+    void RoleCreated(RoleCreated payload, MessageHeaders? headers = null);
+    void RoleUpdated(RoleUpdated payload, MessageHeaders? headers = null);
+    void RoleDeleted(RoleDeleted payload, MessageHeaders? headers = null);
+    void RoleAssigned(RoleAssigned payload, MessageHeaders? headers = null);
+    void RoleRevoked(RoleRevoked payload, MessageHeaders? headers = null);
+
+    // Stubs — Epic V (Policy entity) hasn't shipped to main yet. Calling
+    // these throws NotImplementedException so accidental wiring fails
+    // loudly rather than silently no-op'ing. Once Epic V lands, drop the
+    // throws and stage outbox rows just like the Role helpers above.
+    void PolicyCreated(PolicyCreated payload, MessageHeaders? headers = null);
+    void PolicyUpdated(PolicyUpdated payload, MessageHeaders? headers = null);
+    void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null);
+}

--- a/src/Andy.Rbac/Messaging/OutboxEntry.cs
+++ b/src/Andy.Rbac/Messaging/OutboxEntry.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Messaging;
+
+// Transactional outbox row per ADR 0001. Publishers write to this table
+// in the same transaction as the domain change that produced the message;
+// the OutboxDispatcher background worker drains pending rows to the bus.
+// This guarantees at-least-once delivery without dual-write consistency
+// problems — a crash between commit and publish leaves the row pending
+// and it is picked up on the next dispatcher tick.
+public class OutboxEntry
+{
+    // Primary key. Also used as the MsgId when published — the outbox
+    // row id IS the message id, so reprocessing is naturally idempotent
+    // from the consumer's perspective.
+    public Guid Id { get; set; }
+
+    // NATS subject the message will be published to. Must follow the
+    // taxonomy defined in ADR 0001:
+    //   andy.<service>.events.<entity>.<id>.<kind>
+    public string Subject { get; set; } = string.Empty;
+
+    // Fully-qualified CLR type name of the payload. Used by consumers
+    // to pick the right deserialization target. Optional — subjects
+    // already encode intent, but this is a useful safety net.
+    public string? PayloadType { get; set; }
+
+    // JSON-encoded payload. Stored as text for provider portability.
+    public string PayloadJson { get; set; } = "{}";
+
+    // Correlation chain, copied into MessageHeaders at publish time.
+    public Guid CorrelationId { get; set; }
+    public Guid? CausationId { get; set; }
+    public int Generation { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    // Nullable sentinels for dispatch state. PublishedAt is set on the
+    // first successful publish; rows are never deleted so the outbox
+    // doubles as an audit log. A separate retention policy job may
+    // purge rows older than N days.
+    public DateTimeOffset? PublishedAt { get; set; }
+
+    // Attempt counter and last-error diagnostics for failed publishes.
+    // The dispatcher uses these to implement exponential backoff and
+    // to surface poison messages.
+    public int AttemptCount { get; set; }
+    public DateTimeOffset? LastAttemptAt { get; set; }
+    public string? LastError { get; set; }
+}

--- a/tests/Andy.Rbac.Api.Tests/Services/RbacEventPublisherTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/RbacEventPublisherTests.cs
@@ -1,0 +1,170 @@
+using Andy.Rbac.Api.Services;
+using Andy.Rbac.Infrastructure.Messaging;
+using Andy.Rbac.Messaging;
+using Andy.Rbac.Messaging.Events;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Andy.Rbac.Api.Tests.Services;
+
+// AL2 + AL3 + AL4 — verifies that lifecycle events from RoleService land
+// on the OutboxEntry table inside the same transaction as the domain
+// row. The OutboxDispatcher (a separate hosted worker) is responsible
+// for actually pushing to NATS — those tests live alongside the
+// dispatcher.
+public class RbacEventPublisherTests
+{
+    [Fact]
+    public async Task RoleCreated_writes_outbox_row_with_correct_subject()
+    {
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var publisher = new RbacEventPublisher(context);
+        var service = new RoleService(context, Mock.Of<ILogger<RoleService>>(), publisher);
+
+        var result = await service.CreateAsync(new CreateRoleRequest(
+            Code: "writer",
+            Name: "Writer",
+            Description: null,
+            ApplicationCode: "test-app"));
+
+        var entry = await context.Outbox.SingleAsync();
+        entry.Subject.Should().Be($"andy.rbac.events.role.{result.Role.Id}.created");
+        entry.PayloadType.Should().Be(typeof(RoleCreated).FullName);
+        entry.Generation.Should().Be(0);
+        entry.PublishedAt.Should().BeNull();
+        entry.PayloadJson.Should().Contain("\"writer\"");
+        entry.PayloadJson.Should().Contain("\"test-app\"");
+    }
+
+    [Fact]
+    public async Task RoleDeleted_writes_outbox_row_with_correct_subject()
+    {
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var publisher = new RbacEventPublisher(context);
+        var service = new RoleService(context, Mock.Of<ILogger<RoleService>>(), publisher);
+        var created = await service.CreateAsync(new CreateRoleRequest(
+            Code: "doomed",
+            Name: "Doomed",
+            Description: null,
+            ApplicationCode: "test-app"));
+
+        var deleted = await service.DeleteAsync(created.Role.Id);
+
+        deleted.Should().BeTrue();
+        var entries = await context.Outbox.OrderBy(e => e.CreatedAt).ToListAsync();
+        entries.Should().HaveCount(2);
+        entries[1].Subject.Should().Be($"andy.rbac.events.role.{created.Role.Id}.deleted");
+        entries[1].PayloadType.Should().Be(typeof(RoleDeleted).FullName);
+    }
+
+    [Fact]
+    public async Task RoleAssigned_writes_outbox_row_with_assignment_id()
+    {
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var publisher = new RbacEventPublisher(context);
+        var service = new RoleService(context, Mock.Of<ILogger<RoleService>>(), publisher);
+        // editor role + admin-user already in seed (TestDbContextFactory).
+
+        var msg = await service.AssignToSubjectAsync(
+            subjectExternalId: "no-role-user",
+            roleCode: "viewer");
+
+        msg.Should().StartWith("Successfully assigned");
+        var entry = await context.Outbox
+            .Where(e => e.Subject.Contains(".subject_role."))
+            .SingleAsync();
+        entry.Subject.Should().EndWith(".granted");
+        entry.PayloadType.Should().Be(typeof(RoleAssigned).FullName);
+    }
+
+    [Fact]
+    public async Task RoleRevoked_writes_outbox_row()
+    {
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var publisher = new RbacEventPublisher(context);
+        var service = new RoleService(context, Mock.Of<ILogger<RoleService>>(), publisher);
+        await service.AssignToSubjectAsync("no-role-user", "viewer");
+
+        var msg = await service.RevokeFromSubjectAsync("no-role-user", "viewer");
+
+        msg.Should().StartWith("Successfully revoked");
+        var entries = await context.Outbox
+            .Where(e => e.Subject.Contains(".subject_role."))
+            .OrderBy(e => e.CreatedAt)
+            .ToListAsync();
+        entries.Should().HaveCount(2);
+        entries[1].Subject.Should().EndWith(".revoked");
+        entries[1].PayloadType.Should().Be(typeof(RoleRevoked).FullName);
+    }
+
+    [Fact]
+    public async Task Outbox_row_uses_canonical_event_json_options_snake_case()
+    {
+        using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
+        var publisher = new RbacEventPublisher(context);
+        var service = new RoleService(context, Mock.Of<ILogger<RoleService>>(), publisher);
+
+        var result = await service.CreateAsync(new CreateRoleRequest(
+            Code: "naming",
+            Name: "Naming",
+            Description: null,
+            ApplicationCode: "test-app"));
+
+        var entry = await context.Outbox.SingleAsync();
+        // Snake case per EventJson.Options — application_code / parent_role_code / occurred_at.
+        entry.PayloadJson.Should().Contain("\"role_id\"");
+        entry.PayloadJson.Should().Contain("\"application_code\"");
+        entry.PayloadJson.Should().Contain("\"is_system\"");
+        entry.PayloadJson.Should().NotContain("\"RoleId\"");
+        entry.PayloadJson.Should().NotContain("\"applicationCode\"");
+        result.Role.Code.Should().Be("naming");
+    }
+
+    [Fact]
+    public void PolicyCreated_throws_until_Epic_V_lands()
+    {
+        // Sanity check on the AL4 stub: calling the Policy.* helpers must
+        // fail loudly rather than silently no-op so accidental wiring
+        // shows up immediately in tests.
+        var publisher = new RbacEventPublisher(null!); // ctor doesn't dereference
+        var act = () => publisher.PolicyCreated(new PolicyCreated(
+            PolicyId: Guid.NewGuid(),
+            Code: "test",
+            ApplicationCode: null,
+            OccurredAt: DateTimeOffset.UtcNow));
+        act.Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
+    public void Headers_starting_above_max_generation_drop_silently()
+    {
+        // Defense-in-depth: should be unreachable in rbac (publisher-only
+        // service starts every chain at generation 0), but if we ever
+        // wire event-driven reactions, exceeding MaxGeneration must NOT
+        // append a runaway row to the outbox.
+        var options = new DbContextOptionsBuilder<Andy.Rbac.Infrastructure.Data.RbacDbContext>()
+            .UseInMemoryDatabase($"db-{Guid.NewGuid()}")
+            .Options;
+        using var ctx = new Andy.Rbac.Infrastructure.Data.RbacDbContext(options);
+        var publisher = new RbacEventPublisher(ctx);
+        var overflowed = new MessageHeaders(
+            MsgId: Guid.NewGuid(),
+            CorrelationId: Guid.NewGuid(),
+            CausationId: Guid.NewGuid(),
+            Generation: MessageHeaders.MaxGeneration + 1);
+
+        publisher.RoleCreated(new RoleCreated(
+            RoleId: Guid.NewGuid(),
+            Code: "x",
+            Name: "X",
+            ApplicationCode: null,
+            ParentRoleCode: null,
+            IsSystem: false,
+            OccurredAt: DateTimeOffset.UtcNow), overflowed);
+
+        ctx.Outbox.Should().BeEmpty();
+    }
+}

--- a/tests/Andy.Rbac.Api.Tests/Services/RoleServiceTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/RoleServiceTests.cs
@@ -15,7 +15,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.GetAllAsync();
@@ -32,7 +32,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.GetAllAsync("test-app");
@@ -47,7 +47,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
         var roleId = Guid.Parse("55555555-5555-5555-5555-555555555555");
 
         // Act
@@ -64,7 +64,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.GetByIdAsync(Guid.NewGuid());
@@ -78,7 +78,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
         var request = new CreateRoleRequest("new-role", "New Role", "Description", "test-app");
 
         // Act
@@ -97,7 +97,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
         var request = new CreateRoleRequest("new-role", "New Role", null, "non-existent-app");
 
         // Act & Assert
@@ -110,7 +110,7 @@ public class RoleServiceTests
     {
         // Issue #46 — cycle detection should not reject acyclic chains.
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         var result = await service.CreateAsync(
             new CreateRoleRequest("inheritor", "Inheritor", null, "test-app", ParentRoleCode: "admin"));
@@ -148,7 +148,7 @@ public class RoleServiceTests
         roleA.ParentRoleId = roleB.Id;
         await context.SaveChangesAsync();
 
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.CreateAsync(new CreateRoleRequest(
@@ -160,7 +160,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Create a non-system role to delete
         var created = await service.CreateAsync(new CreateRoleRequest("to-delete", "To Delete", null, "test-app"));
@@ -177,7 +177,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
         var adminRoleId = Guid.Parse("55555555-5555-5555-5555-555555555555");
 
         // Act & Assert
@@ -190,7 +190,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act - assign editor role to no-role user
         var result = await service.AssignToSubjectAsync("no-role-user", "editor");
@@ -204,7 +204,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act - try to assign admin role to admin user again
         var result = await service.AssignToSubjectAsync("admin-user", "admin");
@@ -218,7 +218,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.AssignToSubjectAsync("non-existent-user", "admin");
@@ -233,7 +233,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.AssignToSubjectAsync("admin-user", "non-existent-role");
@@ -248,7 +248,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act - revoke admin role from admin user
         var result = await service.RevokeFromSubjectAsync("admin-user", "admin");
@@ -262,7 +262,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act - try to revoke role that isn't assigned
         var result = await service.RevokeFromSubjectAsync("viewer-user", "admin");
@@ -276,7 +276,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Act
         var result = await service.AssignToTeamAsync("test-team", "viewer");
@@ -290,7 +290,7 @@ public class RoleServiceTests
     {
         // Arrange
         using var context = await TestDbContextFactory.CreateWithSeedDataAsync();
-        var service = new RoleService(context, _loggerMock.Object);
+        var service = new RoleService(context, _loggerMock.Object, new Andy.Rbac.Infrastructure.Messaging.RbacEventPublisher(context));
 
         // Assign once
         await service.AssignToTeamAsync("test-team", "viewer");


### PR DESCRIPTION
## Summary

Ships the publisher half of Epic AL on rbac:

- **AL1 — NATS substrate** ported from andy-tasks (`NatsMessageBus`, `InMemoryMessageBus`, `NatsStreamProvisioner`). One stream `ANDY_RBAC` with 90-day retention covering `andy.rbac.events.>` + `andy.rbac.dlq.>`.
- **AL2 — Transactional outbox** (`OutboxEntry` + `OutboxDispatcher`). Postgres gets a partial index on `(CreatedAt) WHERE PublishedAt IS NULL`; SQLite/InMemory get a non-filtered index so Conductor's embedded launcher keeps working.
- **AL3 — Subject scheme** `andy.rbac.events.{entity}.{id}.{kind}`. Implemented: `role.{id}.{created|updated|deleted}`, `subject_role.{id}.{granted|revoked}`. `Policy.*` helpers reserved as `NotImplementedException` stubs until Epic V ships the Policy entity.
- **AL4 — Lifecycle emission**: `RoleService` publishes on Create / Delete / Assign / Revoke via `IRbacEventPublisher`, which stages the outbox row in the same `SaveChangesAsync` as the domain row.

EF migration `20260508005828_AddOutboxTable` adds the `outbox` table.

## Why

andy-tasks AD4a and andy-docs `RetentionCascadeWorker` need to react to role changes over NATS instead of polling rbac. Establishing the publisher half here unblocks both consumers.

## Test plan

- [x] `dotnet build` — solution clean (0/0).
- [x] `dotnet test` — 401/401 passing locally (7 new `RbacEventPublisherTests` cover Create / Delete / Assign / Revoke outbox staging, snake-case JSON wire format, the Policy stub, and the generation-overflow guard).
- [ ] CI green on PR.
- [ ] Smoke-test once merged: spin up the Api against a NATS cluster (`Messaging:Nats:Url` set), create a role via the existing endpoint, observe `andy.rbac.events.role.{id}.created` on the bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)