### PR TITLE
feat(policies): Epic V critical path — Policy entity + service + endpoints

### DIFF
--- a/src/Andy.Rbac.Api/Controllers/PoliciesController.cs
+++ b/src/Andy.Rbac.Api/Controllers/PoliciesController.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Rbac.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Rbac.Api.Controllers;
+
+/// <summary>
+/// Policy catalog endpoints (Epic V3). Read paths are open to any
+/// authenticated caller; mutating paths require admin.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class PoliciesController : ControllerBase
+{
+    private readonly IPolicyService _policyService;
+
+    public PoliciesController(IPolicyService policyService)
+    {
+        _policyService = policyService;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<PolicyDetail>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPolicies(CancellationToken ct)
+    {
+        var result = await _policyService.GetAllAsync(ct);
+        return Ok(result.Policies);
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(PolicyDetail), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPolicy(Guid id, CancellationToken ct)
+    {
+        var result = await _policyService.GetByIdAsync(id, ct);
+        if (result == null) return NotFound();
+        return Ok(result.Policy);
+    }
+
+    [HttpGet("by-code/{code}")]
+    [ProducesResponseType(typeof(PolicyDetail), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPolicyByCode(string code, CancellationToken ct)
+    {
+        var result = await _policyService.GetByCodeAsync(code, ct);
+        if (result == null) return NotFound();
+        return Ok(result.Policy);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PolicyDetail), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreatePolicy([FromBody] CreatePolicyRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _policyService.CreateAsync(request, ct);
+            return CreatedAtAction(nameof(GetPolicy), new { id = result.Policy.Id }, result.Policy);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(PolicyDetail), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> UpdatePolicy(Guid id, [FromBody] UpdatePolicyRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _policyService.UpdateAsync(id, request, ct);
+            if (result == null) return NotFound();
+            return Ok(result.Policy);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeletePolicy(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var deleted = await _policyService.DeleteAsync(id, ct);
+            if (!deleted) return NotFound();
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+}

--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -26,7 +26,129 @@ public static class DataSeeder
         await SeedActionsAsync(db, ct);
         await SeedApplicationsAsync(db, ct);
         await SeedGlobalRolesAsync(db, ct);
+        await SeedStockPoliciesAsync(db, ct);
         await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// V2: seed the six stock policies that the simulator binds to. These are
+    /// flagged <c>IsSystem</c> so they cannot be edited or deleted. The Code
+    /// column is the cross-service identifier referenced by andy-tasks
+    /// <c>Goal.PolicyId</c> / <c>DelegationContract.PolicyId</c>.
+    /// </summary>
+    private static async Task SeedStockPoliciesAsync(RbacDbContext db, CancellationToken ct)
+    {
+        // Inserts go via SaveChangesAsync at the end of SeedAsync, so we
+        // also need to flag any policy added in this pass as Modified=No
+        // for re-runs to be idempotent.
+        var stockPolicies = new[]
+        {
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "read-only",
+                Name = "Read-only",
+                Criticality = PolicyCriticality.Low,
+                Description = "Agent may read repository state but cannot mutate anything.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = false,
+                    ["requirePostGate"] = false,
+                    ["retentionDays"] = 30,
+                    ["archiveTier"] = "default",
+                },
+                IsSystem = true,
+            },
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "write-branch",
+                Name = "Write to feature branch",
+                Criticality = PolicyCriticality.Low,
+                Description = "Agent may write commits and push to non-default branches only.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = false,
+                    ["requirePostGate"] = false,
+                    ["retentionDays"] = 30,
+                    ["archiveTier"] = "default",
+                },
+                IsSystem = true,
+            },
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "sandboxed",
+                Name = "Sandboxed",
+                Criticality = PolicyCriticality.Medium,
+                Description = "Agent runs in an isolated sandbox; no external network or production access.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = false,
+                    ["requirePostGate"] = false,
+                    ["retentionDays"] = 30,
+                    ["archiveTier"] = "default",
+                },
+                IsSystem = true,
+            },
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "no-prod",
+                Name = "No production access",
+                Criticality = PolicyCriticality.High,
+                Description = "Pre-execution gate on any deploy-class task; blocks production-touching tools.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = true,
+                    ["requirePostGate"] = false,
+                    ["blocksDeployTools"] = true,
+                    ["retentionDays"] = 365,
+                    ["archiveTier"] = "medium",
+                },
+                IsSystem = true,
+            },
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "high-risk",
+                Name = "High risk",
+                Criticality = PolicyCriticality.Critical,
+                Description = "Pre + post execution gates on every task; full action-log retention.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = true,
+                    ["requirePostGate"] = true,
+                    ["retentionDays"] = 2555, // ~7 years
+                    ["archiveTier"] = "high",
+                },
+                IsSystem = true,
+            },
+            new Policy
+            {
+                Id = Guid.NewGuid(),
+                Code = "draft-only",
+                Name = "Draft only",
+                Criticality = PolicyCriticality.Medium,
+                Description = "Post-execution gate on publishable artifacts; outputs marked draft until reviewed.",
+                Rules = new Dictionary<string, object>
+                {
+                    ["requirePreGate"] = false,
+                    ["requirePostGate"] = true,
+                    ["retentionDays"] = 30,
+                    ["archiveTier"] = "default",
+                },
+                IsSystem = true,
+            },
+        };
+
+        foreach (var policy in stockPolicies)
+        {
+            if (!await db.Policies.AnyAsync(p => p.Code == policy.Code, ct))
+            {
+                db.Policies.Add(policy);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddScoped<IApplicationService, ApplicationService>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<ITeamService, TeamService>();
 builder.Services.AddScoped<ISubjectService, SubjectService>();
+builder.Services.AddScoped<IPolicyService, PolicyService>();
 
 // Epic AL — NATS messaging substrate.
 //

--- a/src/Andy.Rbac.Api/Services/IPolicyService.cs
+++ b/src/Andy.Rbac.Api/Services/IPolicyService.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Rbac.Models;
+
+namespace Andy.Rbac.Api.Services;
+
+/// <summary>
+/// Service for managing policies (Epic V). Policies are catalog rows that
+/// downstream services (andy-tasks, andy-docs, Conductor) reference by
+/// <see cref="PolicyDetail.Code"/> to drive auto-gating, retention, and
+/// action-bus enforcement decisions.
+/// </summary>
+public interface IPolicyService
+{
+    Task<PolicyListResult> GetAllAsync(CancellationToken ct = default);
+    Task<PolicyDetailResult?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<PolicyDetailResult?> GetByCodeAsync(string code, CancellationToken ct = default);
+    Task<PolicyDetailResult> CreateAsync(CreatePolicyRequest request, CancellationToken ct = default);
+    Task<PolicyDetailResult?> UpdateAsync(Guid id, UpdatePolicyRequest request, CancellationToken ct = default);
+    Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+}
+
+public record PolicyDetail(
+    Guid Id,
+    string Code,
+    string Name,
+    PolicyCriticality Criticality,
+    Dictionary<string, object>? Rules,
+    string? Description,
+    bool IsSystem,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+
+public record PolicyListResult(List<PolicyDetail> Policies);
+public record PolicyDetailResult(PolicyDetail Policy);
+
+public record CreatePolicyRequest(
+    string Code,
+    string Name,
+    PolicyCriticality Criticality,
+    Dictionary<string, object>? Rules = null,
+    string? Description = null);
+
+public record UpdatePolicyRequest(
+    string? Name = null,
+    PolicyCriticality? Criticality = null,
+    Dictionary<string, object>? Rules = null,
+    string? Description = null);

--- a/src/Andy.Rbac.Api/Services/PolicyService.cs
+++ b/src/Andy.Rbac.Api/Services/PolicyService.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Messaging;
+using Andy.Rbac.Messaging.Events;
+using Andy.Rbac.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Rbac.Api.Services;
+
+/// <summary>
+/// Service for managing policies. Mirrors <see cref="RoleService"/>'s shape:
+/// stages outbox events on the same DbContext as the domain write so the
+/// transactional outbox (AL2) commits both atomically.
+/// </summary>
+public class PolicyService : IPolicyService
+{
+    private readonly RbacDbContext _db;
+    private readonly ILogger<PolicyService> _logger;
+    private readonly IRbacEventPublisher _events;
+
+    public PolicyService(RbacDbContext db, ILogger<PolicyService> logger, IRbacEventPublisher events)
+    {
+        _db = db;
+        _logger = logger;
+        _events = events;
+    }
+
+    public async Task<PolicyListResult> GetAllAsync(CancellationToken ct = default)
+    {
+        var policies = await _db.Policies
+            .AsNoTracking()
+            .OrderBy(p => p.Code)
+            .Select(p => MapToDetail(p))
+            .ToListAsync(ct);
+
+        return new PolicyListResult(policies);
+    }
+
+    public async Task<PolicyDetailResult?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        var policy = await _db.Policies.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id, ct);
+        return policy == null ? null : new PolicyDetailResult(MapToDetail(policy));
+    }
+
+    public async Task<PolicyDetailResult?> GetByCodeAsync(string code, CancellationToken ct = default)
+    {
+        var policy = await _db.Policies.AsNoTracking().FirstOrDefaultAsync(p => p.Code == code, ct);
+        return policy == null ? null : new PolicyDetailResult(MapToDetail(policy));
+    }
+
+    public async Task<PolicyDetailResult> CreateAsync(CreatePolicyRequest request, CancellationToken ct = default)
+    {
+        if (await _db.Policies.AnyAsync(p => p.Code == request.Code, ct))
+            throw new InvalidOperationException($"Policy with code '{request.Code}' already exists");
+
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Code = request.Code,
+            Name = request.Name,
+            Criticality = request.Criticality,
+            Rules = request.Rules,
+            Description = request.Description,
+            IsSystem = false,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.Policies.Add(policy);
+        _events.PolicyCreated(new PolicyCreated(
+            PolicyId: policy.Id,
+            Code: policy.Code,
+            ApplicationCode: null,
+            OccurredAt: DateTimeOffset.UtcNow));
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Created policy {PolicyCode}", policy.Code);
+
+        return new PolicyDetailResult(MapToDetail(policy));
+    }
+
+    public async Task<PolicyDetailResult?> UpdateAsync(Guid id, UpdatePolicyRequest request, CancellationToken ct = default)
+    {
+        var policy = await _db.Policies.FirstOrDefaultAsync(p => p.Id == id, ct);
+        if (policy == null) return null;
+
+        if (policy.IsSystem)
+            throw new InvalidOperationException("Cannot modify system policies");
+
+        if (request.Name != null) policy.Name = request.Name;
+        if (request.Criticality.HasValue) policy.Criticality = request.Criticality.Value;
+        if (request.Rules != null) policy.Rules = request.Rules;
+        if (request.Description != null) policy.Description = request.Description;
+        policy.UpdatedAt = DateTimeOffset.UtcNow;
+
+        _events.PolicyUpdated(new PolicyUpdated(
+            PolicyId: policy.Id,
+            Code: policy.Code,
+            ApplicationCode: null,
+            OccurredAt: DateTimeOffset.UtcNow));
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Updated policy {PolicyCode}", policy.Code);
+
+        return new PolicyDetailResult(MapToDetail(policy));
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var policy = await _db.Policies.FindAsync([id], ct);
+        if (policy == null) return false;
+
+        if (policy.IsSystem)
+            throw new InvalidOperationException("Cannot delete system policies");
+
+        _db.Policies.Remove(policy);
+        _events.PolicyDeleted(new PolicyDeleted(
+            PolicyId: policy.Id,
+            Code: policy.Code,
+            ApplicationCode: null,
+            OccurredAt: DateTimeOffset.UtcNow));
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Deleted policy {PolicyCode}", policy.Code);
+
+        return true;
+    }
+
+    private static PolicyDetail MapToDetail(Policy p) => new(
+        p.Id,
+        p.Code,
+        p.Name,
+        p.Criticality,
+        p.Rules,
+        p.Description,
+        p.IsSystem,
+        p.CreatedAt,
+        p.UpdatedAt);
+}

--- a/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508164523_AddPolicyTable.Designer.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508164523_AddPolicyTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Rbac.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Rbac.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(RbacDbContext))]
-    partial class RbacDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508164523_AddPolicyTable")]
+    partial class AddPolicyTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508164523_AddPolicyTable.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/Migrations/20260508164523_AddPolicyTable.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Rbac.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPolicyTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "policies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Code = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Criticality = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Rules = table.Column<string>(type: "jsonb", nullable: true),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    IsSystem = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_policies", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_policies_Code",
+                table: "policies",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "policies");
+        }
+    }
+}

--- a/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
@@ -30,9 +30,10 @@ public class RbacDbContext : DbContext
     public DbSet<TeamMember> TeamMembers => Set<TeamMember>();
     public DbSet<TeamRole> TeamRoles => Set<TeamRole>();
     public DbSet<ApiKey> ApiKeys => Set<ApiKey>();
+    public DbSet<Policy> Policies => Set<Policy>();
 
     // AL2: transactional outbox. Domain writes that need to emit cross-
-    // service events (RoleService, future PolicyService) append rows here
+    // service events (RoleService, PolicyService) append rows here
     // inside the same transaction; OutboxDispatcher drains them to NATS.
     public DbSet<OutboxEntry> Outbox => Set<OutboxEntry>();
 
@@ -356,6 +357,24 @@ public class RbacDbContext : DbContext
                 .WithMany()
                 .HasForeignKey(e => e.ApplicationId)
                 .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // Policy (V1). Stock policies are seeded as IsSystem in the
+        // DataSeeder; the Code column is the cross-service identifier
+        // referenced by andy-tasks Goal.PolicyId / DelegationContract.PolicyId.
+        modelBuilder.Entity<Policy>(entity =>
+        {
+            entity.ToTable("policies");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Code).HasMaxLength(64).IsRequired();
+            entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(2000);
+            entity.Property(e => e.Criticality).HasConversion<string>().HasMaxLength(20);
+            var policyRules = entity.Property(e => e.Rules)
+                .HasConversion(dictionaryConverter);
+            if (jsonColumnType != null) policyRules.HasColumnType(jsonColumnType);
+            policyRules.Metadata.SetValueComparer(dictionaryComparer);
+            entity.HasIndex(e => e.Code).IsUnique();
         });
 
         // OutboxEntry (AL2). Stored as plain text columns for provider

--- a/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
@@ -39,13 +39,13 @@ public sealed class RbacEventPublisher : IRbacEventPublisher
         => Stage($"{SubjectPrefix}.subject_role.{payload.AssignmentId}.revoked", payload, headers);
 
     public void PolicyCreated(PolicyCreated payload, MessageHeaders? headers = null)
-        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+        => Stage($"{SubjectPrefix}.policy.{payload.PolicyId}.created", payload, headers);
 
     public void PolicyUpdated(PolicyUpdated payload, MessageHeaders? headers = null)
-        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+        => Stage($"{SubjectPrefix}.policy.{payload.PolicyId}.updated", payload, headers);
 
     public void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null)
-        => throw new NotImplementedException("Policy entity (Epic V) has not shipped to main yet.");
+        => Stage($"{SubjectPrefix}.policy.{payload.PolicyId}.deleted", payload, headers);
 
     private void Stage(string subject, object payload, MessageHeaders? headers)
     {

--- a/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
+++ b/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
@@ -3,14 +3,10 @@
 
 namespace Andy.Rbac.Messaging.Events;
 
-// AL4 Policy lifecycle events — STUB. Epic V (Policy entity + service)
-// shipped as the design doc only; the runtime entity has not landed on
-// main yet. These types and their subject scheme are reserved here so
-// that downstream consumers (andy-docs RetentionCascadeWorker, future
-// PDP cache invalidation) can pin against a stable wire contract while
-// the entity work catches up. The publisher exposes Policy.* helpers
-// that throw NotImplementedException — wiring them to a real entity is
-// a one-line change once Epic V lands.
+// AL4 Policy lifecycle events. Emitted by PolicyService writes via
+// RbacEventPublisher.Policy{Created,Updated,Deleted} on a transactional
+// outbox commit. Consumers: andy-tasks AC3 (auto-gating cache invalidation),
+// andy-tasks AD4/AD4a (retention cascade), andy-docs RetentionCascadeWorker.
 //
 // Subject scheme (AL3): andy.rbac.events.policy.{policy_id}.{kind}
 

--- a/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
+++ b/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
@@ -14,7 +14,7 @@ namespace Andy.Rbac.Messaging;
 // Subject scheme (ADR 0001 + AL3):
 //   andy.rbac.events.role.{role_id}.{created|updated|deleted}
 //   andy.rbac.events.subject_role.{assignment_id}.{granted|revoked}
-//   andy.rbac.events.policy.{policy_id}.{created|updated|deleted}    (stub — Epic V pending)
+//   andy.rbac.events.policy.{policy_id}.{created|updated|deleted}
 public interface IRbacEventPublisher
 {
     void RoleCreated(RoleCreated payload, MessageHeaders? headers = null);
@@ -23,10 +23,6 @@ public interface IRbacEventPublisher
     void RoleAssigned(RoleAssigned payload, MessageHeaders? headers = null);
     void RoleRevoked(RoleRevoked payload, MessageHeaders? headers = null);
 
-    // Stubs — Epic V (Policy entity) hasn't shipped to main yet. Calling
-    // these throws NotImplementedException so accidental wiring fails
-    // loudly rather than silently no-op'ing. Once Epic V lands, drop the
-    // throws and stage outbox rows just like the Role helpers above.
     void PolicyCreated(PolicyCreated payload, MessageHeaders? headers = null);
     void PolicyUpdated(PolicyUpdated payload, MessageHeaders? headers = null);
     void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null);

--- a/src/Andy.Rbac/Models/Policy.cs
+++ b/src/Andy.Rbac/Models/Policy.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Rbac.Models;
+
+/// <summary>
+/// A policy binds delegation contracts, action-bus invocations and approval
+/// gates to a named risk profile. Stock policies (read-only, write-branch,
+/// sandboxed, no-prod, high-risk, draft-only) are seeded as IsSystem; tenants
+/// may register additional non-system policies.
+///
+/// Cross-service identity is by <see cref="Code"/> — andy-tasks stores the
+/// code in <c>Goal.PolicyId</c> / <c>DelegationContract.PolicyId</c>, not the
+/// Guid. The Guid is the storage key and the wire-event identifier.
+/// </summary>
+public class Policy
+{
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Stable slug used by other services as the cross-service identifier
+    /// (e.g. "high-risk", "no-prod", "sandboxed"). Unique within the rbac DB.
+    /// </summary>
+    public required string Code { get; set; }
+
+    public required string Name { get; set; }
+
+    public PolicyCriticality Criticality { get; set; } = PolicyCriticality.Medium;
+
+    /// <summary>
+    /// Free-form rule body, persisted as jsonb on Postgres and TEXT on SQLite.
+    /// Schema is intentionally open: each consumer (Conductor ActionBus per V5,
+    /// andy-tasks AC3 auto-gating, andy-tasks AD4 retention) picks the keys it
+    /// understands. Stable keys defined to date:
+    ///   - <c>retentionDays</c>          (int)    — AD4 row retention override
+    ///   - <c>archiveTier</c>            (string) — AD3/AJ archive tier
+    ///   - <c>requirePreGate</c>         (bool)   — AC3 pre-execution gate
+    ///   - <c>requirePostGate</c>        (bool)   — AC3 post-execution gate
+    ///   - <c>blocksDeployTools</c>      (bool)   — V5 ActionBus deploy guard
+    /// </summary>
+    public Dictionary<string, object>? Rules { get; set; } = new();
+
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// System policies cannot be deleted or have their Code mutated. Stock
+    /// policies (V2 seed) are flagged IsSystem.
+    /// </summary>
+    public bool IsSystem { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Risk classification for a policy. Drives default retention and gate
+/// behaviour in downstream consumers (AD4, AC3, AD7).
+/// </summary>
+public enum PolicyCriticality
+{
+    Low = 0,
+    Medium = 1,
+    High = 2,
+    Critical = 3,
+}

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -62,6 +62,39 @@ public class DataSeederTests
     }
 
     [Fact]
+    public async Task SeedAsync_SeedsStockPolicies()
+    {
+        using var context = CreateContext();
+
+        await DataSeeder.SeedAsync(context);
+
+        var policies = await context.Policies.ToListAsync();
+        policies.Should().Contain(p => p.Code == "read-only" && p.IsSystem);
+        policies.Should().Contain(p => p.Code == "write-branch" && p.IsSystem);
+        policies.Should().Contain(p => p.Code == "sandboxed" && p.IsSystem);
+        policies.Should().Contain(p => p.Code == "no-prod" && p.IsSystem);
+        policies.Should().Contain(p => p.Code == "high-risk" && p.IsSystem);
+        policies.Should().Contain(p => p.Code == "draft-only" && p.IsSystem);
+
+        var highRisk = policies.First(p => p.Code == "high-risk");
+        highRisk.Criticality.Should().Be(Andy.Rbac.Models.PolicyCriticality.Critical);
+        highRisk.Rules.Should().NotBeNull();
+        highRisk.Rules!["requirePreGate"].Should().Be(true);
+        highRisk.Rules["requirePostGate"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task SeedAsync_StockPolicies_AreIdempotent()
+    {
+        using var context = CreateContext();
+
+        await DataSeeder.SeedAsync(context);
+        await DataSeeder.SeedAsync(context);
+
+        (await context.Policies.CountAsync(p => p.IsSystem)).Should().Be(6);
+    }
+
+    [Fact]
     public async Task SeedAsync_SeedsGlobalRoles()
     {
         // Arrange

--- a/tests/Andy.Rbac.Api.Tests/Services/PolicyServiceTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/PolicyServiceTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Rbac.Api.Services;
+using Andy.Rbac.Infrastructure.Messaging;
+using Andy.Rbac.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Andy.Rbac.Api.Tests.Services;
+
+public class PolicyServiceTests
+{
+    private readonly Mock<ILogger<PolicyService>> _loggerMock = new();
+
+    [Fact]
+    public async Task CreateAsync_PersistsPolicyAndStagesOutbox()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var result = await service.CreateAsync(new CreatePolicyRequest(
+            Code: "tenant-policy",
+            Name: "Tenant Policy",
+            Criticality: PolicyCriticality.Medium,
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 90 },
+            Description: "Tenant override"));
+
+        result.Policy.Code.Should().Be("tenant-policy");
+        result.Policy.Criticality.Should().Be(PolicyCriticality.Medium);
+        result.Policy.IsSystem.Should().BeFalse();
+
+        var stored = await ctx.Policies.FirstAsync(p => p.Code == "tenant-policy");
+        stored.Description.Should().Be("Tenant override");
+
+        var outbox = await ctx.Outbox.ToListAsync();
+        outbox.Should().ContainSingle();
+        outbox[0].Subject.Should().StartWith("andy.rbac.events.policy.");
+        outbox[0].Subject.Should().EndWith(".created");
+    }
+
+    [Fact]
+    public async Task CreateAsync_DuplicateCode_Throws()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        await service.CreateAsync(new CreatePolicyRequest("dup", "Dup", PolicyCriticality.Low));
+
+        var act = () => service.CreateAsync(new CreatePolicyRequest("dup", "Dup2", PolicyCriticality.Low));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*already exists*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StagesUpdateOutbox()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest("p1", "P1", PolicyCriticality.Low));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        var updated = await service.UpdateAsync(created.Policy.Id, new UpdatePolicyRequest(Name: "P1 Renamed"));
+
+        updated.Should().NotBeNull();
+        updated!.Policy.Name.Should().Be("P1 Renamed");
+
+        var outbox = await ctx.Outbox.ToListAsync();
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".updated"));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SystemPolicy_Throws()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        ctx.Policies.Add(new Policy
+        {
+            Id = Guid.NewGuid(),
+            Code = "high-risk",
+            Name = "High risk",
+            Criticality = PolicyCriticality.Critical,
+            IsSystem = true,
+        });
+        await ctx.SaveChangesAsync();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+        var system = await ctx.Policies.FirstAsync();
+
+        var act = () => service.UpdateAsync(system.Id, new UpdatePolicyRequest(Name: "renamed"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*system policies*");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StagesDeleteOutbox()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest("dp", "Dp", PolicyCriticality.Low));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        var deleted = await service.DeleteAsync(created.Policy.Id);
+
+        deleted.Should().BeTrue();
+        (await ctx.Policies.AnyAsync(p => p.Id == created.Policy.Id)).Should().BeFalse();
+        (await ctx.Outbox.ToListAsync()).Should().ContainSingle(e => e.Subject.EndsWith(".deleted"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SystemPolicy_Throws()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        ctx.Policies.Add(new Policy
+        {
+            Id = Guid.NewGuid(),
+            Code = "high-risk",
+            Name = "High risk",
+            Criticality = PolicyCriticality.Critical,
+            IsSystem = true,
+        });
+        await ctx.SaveChangesAsync();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+        var system = await ctx.Policies.FirstAsync();
+
+        var act = () => service.DeleteAsync(system.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*system policies*");
+    }
+
+    [Fact]
+    public async Task GetByCodeAsync_ReturnsPolicy()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+        await service.CreateAsync(new CreatePolicyRequest("findme", "FindMe", PolicyCriticality.Low));
+
+        var result = await service.GetByCodeAsync("findme");
+
+        result.Should().NotBeNull();
+        result!.Policy.Code.Should().Be("findme");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsPoliciesSortedByCode()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+        await service.CreateAsync(new CreatePolicyRequest("z", "Z", PolicyCriticality.Low));
+        await service.CreateAsync(new CreatePolicyRequest("a", "A", PolicyCriticality.Low));
+
+        var result = await service.GetAllAsync();
+
+        result.Policies.Should().HaveCount(2);
+        result.Policies[0].Code.Should().Be("a");
+        result.Policies[1].Code.Should().Be("z");
+    }
+}

--- a/tests/Andy.Rbac.Api.Tests/Services/RbacEventPublisherTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/RbacEventPublisherTests.cs
@@ -124,18 +124,26 @@ public class RbacEventPublisherTests
     }
 
     [Fact]
-    public void PolicyCreated_throws_until_Epic_V_lands()
+    public async Task PolicyCreated_stages_outbox_with_policy_subject()
     {
-        // Sanity check on the AL4 stub: calling the Policy.* helpers must
-        // fail loudly rather than silently no-op so accidental wiring
-        // shows up immediately in tests.
-        var publisher = new RbacEventPublisher(null!); // ctor doesn't dereference
-        var act = () => publisher.PolicyCreated(new PolicyCreated(
-            PolicyId: Guid.NewGuid(),
-            Code: "test",
+        var options = new DbContextOptionsBuilder<Andy.Rbac.Infrastructure.Data.RbacDbContext>()
+            .UseInMemoryDatabase($"db-{Guid.NewGuid()}")
+            .Options;
+        await using var context = new Andy.Rbac.Infrastructure.Data.RbacDbContext(options);
+        var publisher = new RbacEventPublisher(context);
+
+        var policyId = Guid.NewGuid();
+        publisher.PolicyCreated(new PolicyCreated(
+            PolicyId: policyId,
+            Code: "high-risk",
             ApplicationCode: null,
             OccurredAt: DateTimeOffset.UtcNow));
-        act.Should().Throw<NotImplementedException>();
+        await context.SaveChangesAsync();
+
+        var entry = await context.Outbox.SingleAsync();
+        entry.Subject.Should().Be($"andy.rbac.events.policy.{policyId}.created");
+        entry.PayloadJson.Should().Contain("\"policy_id\"");
+        entry.PayloadJson.Should().Contain("\"high-risk\"");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Ships the Epic V critical path that was closed in the tracker on 2026-04-21 but never actually landed on main: Policy entity, DbSet, migration, six stock policies, PolicyService, PoliciesController, and the AL4 publisher un-stub.
- Discovered while reassessing andy-tasks blockers after AL1–AL4 (#65) merged — the role/subject_role events shipped, but every andy-tasks consumer (AC3, AD4, AD7) actually needs `andy.rbac.events.policy.*` events, which were stuck behind a `NotImplementedException("Policy entity (Epic V) has not shipped to main yet.")` stub.
- After this lands, andy-tasks AC3 (auto-gating policy lookup), AD4 (retention policy snapshot), and AD7 (critical-flag retention propagation) unblock for Phase B implementation.

## What ships
- **V1** — `Policy` model with `Code` (cross-service identifier), `Name`, `Criticality` (Low/Medium/High/Critical), `Rules` (jsonb / TEXT-on-SQLite), `Description`, `IsSystem`, timestamps. Migration `20260508164523_AddPolicyTable`.
- **V2** — six stock policies seeded as `IsSystem` (read-only, write-branch, sandboxed, no-prod, high-risk, draft-only) with rule keys for `requirePreGate`, `requirePostGate`, `blocksDeployTools`, `retentionDays`, `archiveTier`. Idempotent on re-seed.
- **V3** — `IPolicyService` / `PolicyService` (CRUD, system-policy guard, transactional outbox staging) and `PoliciesController` (GET, GET-by-id, GET-by-code, POST, PUT, DELETE).
- **V10** — `PolicyServiceTests` (8 tests, CRUD + duplicate guard + system-policy guard + outbox subject scheme) and stock-policy `DataSeederTests`.
- **AL4 un-stub** — `RbacEventPublisher.PolicyCreated/Updated/Deleted` now stage outbox rows on `andy.rbac.events.policy.{policy_id}.{kind}` exactly like the Role helpers, replacing the Epic-V-pending `NotImplementedException` stubs from `2d8c656`.

## Not in scope
- V5 Conductor ActionBus enforcement (different repo).
- V7 MCP tools `policy.{get,list}`.
- V8 `andy-rbac-cli policies {list,get}`.
- V9 OpenAPI/Swagger ref re-emit (auto-derives from controller; CI ref check follows separately).
- V11 design doc + README + ADR.

These remain genuinely open and should reopen the corresponding Epic V tickets — calling that out here so the tracker stops lying about completion state.

## Test plan
- [x] `dotnet test` — 411 passed (Andy.Rbac.Api.Tests) + 8 passed (Andy.Rbac.Tests). Zero warnings.
- [x] `RbacEventPublisherTests.PolicyCreated_stages_outbox_with_policy_subject` confirms the un-stubbed publisher writes the correct subject + payload.
- [x] `DataSeederTests.SeedAsync_StockPolicies_AreIdempotent` confirms re-seed is a no-op.
- [ ] Smoke test against a running API: `GET /api/policies` returns the six stock policies; `POST /api/policies` round-trips a tenant policy and emits an outbox row; deleting a system policy returns 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)