### PR TITLE
feat(mcp): V7 — policy.list + policy.get MCP tools

### DIFF
--- a/src/Andy.Rbac.Api/Mcp/RbacMcpTools.cs
+++ b/src/Andy.Rbac.Api/Mcp/RbacMcpTools.cs
@@ -17,6 +17,7 @@ public class RbacMcpTools
     private readonly IRoleService _roleService;
     private readonly ITeamService _teamService;
     private readonly ISubjectService _subjectService;
+    private readonly IPolicyService _policyService;
     private readonly ILogger<RbacMcpTools> _logger;
 
     public RbacMcpTools(
@@ -25,6 +26,7 @@ public class RbacMcpTools
         IRoleService roleService,
         ITeamService teamService,
         ISubjectService subjectService,
+        IPolicyService policyService,
         ILogger<RbacMcpTools> logger)
     {
         _evaluator = evaluator;
@@ -32,6 +34,7 @@ public class RbacMcpTools
         _roleService = roleService;
         _teamService = teamService;
         _subjectService = subjectService;
+        _policyService = policyService;
         _logger = logger;
     }
 
@@ -262,6 +265,36 @@ public class RbacMcpTools
         _logger.LogInformation("MCP: Created user {ExternalId}", externalId);
         return new McpUserInfo(subject.Id, subject.ExternalId, subject.Provider, subject.Email, subject.DisplayName, subject.IsActive);
     }
+
+    // ==================== Policy Catalog ====================
+    // V7: read-only access to the policy catalog. Mutating operations stay
+    // on the REST surface so they go through normal admin auth, not MCP.
+
+    [McpServerTool]
+    [Description("List policies in the RBAC catalog (read-only, write-branch, sandboxed, no-prod, high-risk, draft-only, plus any tenant-defined policies).")]
+    public async Task<List<McpPolicyInfo>> ListPolicies()
+    {
+        var result = await _policyService.GetAllAsync();
+        return result.Policies.Select(MapToMcp).ToList();
+    }
+
+    [McpServerTool]
+    [Description("Get a policy by code (e.g., 'high-risk', 'no-prod') with full rule body.")]
+    public async Task<McpPolicyInfo?> GetPolicy(
+        [Description("Policy code (e.g., 'high-risk')")] string code)
+    {
+        var result = await _policyService.GetByCodeAsync(code);
+        return result == null ? null : MapToMcp(result.Policy);
+    }
+
+    private static McpPolicyInfo MapToMcp(PolicyDetail p) => new(
+        p.Id,
+        p.Code,
+        p.Name,
+        p.Criticality.ToString(),
+        p.Rules,
+        p.Description,
+        p.IsSystem);
 }
 
 // ==================== MCP DTOs ====================
@@ -276,3 +309,4 @@ public record McpUserInfo(Guid Id, string ExternalId, string Provider, string? E
 public record McpUserDetail(Guid Id, string ExternalId, string Provider, string? Email, string? DisplayName, bool IsActive, List<McpUserRoleInfo> Roles, List<McpTeamMembershipInfo> Teams);
 public record McpUserRoleInfo(string RoleCode, string? ApplicationCode, string? ResourceInstanceId);
 public record McpTeamMembershipInfo(string TeamCode, string TeamName, string MembershipRole);
+public record McpPolicyInfo(Guid Id, string Code, string Name, string Criticality, Dictionary<string, object>? Rules, string? Description, bool IsSystem);

--- a/tests/Andy.Rbac.Api.Tests/Mcp/RbacMcpToolsTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Mcp/RbacMcpToolsTests.cs
@@ -15,6 +15,7 @@ public class RbacMcpToolsTests
     private readonly Mock<IRoleService> _roleServiceMock = new();
     private readonly Mock<ITeamService> _teamServiceMock = new();
     private readonly Mock<ISubjectService> _subjectServiceMock = new();
+    private readonly Mock<IPolicyService> _policyServiceMock = new();
     private readonly Mock<ILogger<RbacMcpTools>> _loggerMock = new();
 
     private RbacMcpTools CreateTools()
@@ -25,6 +26,7 @@ public class RbacMcpToolsTests
             _roleServiceMock.Object,
             _teamServiceMock.Object,
             _subjectServiceMock.Object,
+            _policyServiceMock.Object,
             _loggerMock.Object);
     }
 
@@ -530,5 +532,63 @@ public class RbacMcpToolsTests
         result.ExternalId.Should().Be("new-user");
         result.Email.Should().Be("new@test.com");
         result.IsActive.Should().BeTrue();
+    }
+
+    // ==================== Policy Catalog Tests ====================
+
+    [Fact]
+    public async Task ListPolicies_ReturnsCatalog()
+    {
+        var tools = CreateTools();
+        var policies = new List<PolicyDetail>
+        {
+            new(Guid.NewGuid(), "high-risk", "High risk", PolicyCriticality.Critical,
+                new Dictionary<string, object> { ["requirePreGate"] = true }, "desc", true,
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new(Guid.NewGuid(), "read-only", "Read-only", PolicyCriticality.Low,
+                null, "desc", true,
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        };
+        _policyServiceMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PolicyListResult(policies));
+
+        var result = await tools.ListPolicies();
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(p => p.Code == "high-risk" && p.Criticality == "Critical" && p.IsSystem);
+        result.Should().Contain(p => p.Code == "read-only" && p.Criticality == "Low");
+    }
+
+    [Fact]
+    public async Task GetPolicy_WithKnownCode_ReturnsPolicy()
+    {
+        var tools = CreateTools();
+        var policy = new PolicyDetail(
+            Guid.NewGuid(), "high-risk", "High risk", PolicyCriticality.Critical,
+            new Dictionary<string, object> { ["requirePreGate"] = true, ["requirePostGate"] = true },
+            "Critical risk profile", true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _policyServiceMock.Setup(x => x.GetByCodeAsync("high-risk", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PolicyDetailResult(policy));
+
+        var result = await tools.GetPolicy("high-risk");
+
+        result.Should().NotBeNull();
+        result!.Code.Should().Be("high-risk");
+        result.Criticality.Should().Be("Critical");
+        result.Rules.Should().NotBeNull();
+        result.Rules!["requirePreGate"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task GetPolicy_WithUnknownCode_ReturnsNull()
+    {
+        var tools = CreateTools();
+        _policyServiceMock.Setup(x => x.GetByCodeAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PolicyDetailResult?)null);
+
+        var result = await tools.GetPolicy("missing");
+
+        result.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Summary
- Adds two read-only MCP tools (`ListPolicies`, `GetPolicy`) backed by `IPolicyService` from #66.
- Closes rivoli-ai/andy-rbac#24.

## What ships
- `RbacMcpTools.ListPolicies` — returns the full catalog as a list of `McpPolicyInfo` rows.
- `RbacMcpTools.GetPolicy(code)` — returns a single policy with its rule body, or null when the code is unknown.
- `McpPolicyInfo` DTO mirroring REST `PolicyDetail` but with `Criticality` as a string (matches existing `McpRoleInfo` pattern).
- 3 new unit tests for the new methods.

## Why read-only
Mutating policy operations stay on the REST surface (`PoliciesController`). MCP tools intentionally expose only read-only access so an agent context invoking a tool cannot edit policy from inside the same call — admin authorization paths shouldn't move through MCP.

## Test plan
- [x] `dotnet test` — 414 passed, 0 warnings.
- [x] `RbacMcpToolsTests` — `ListPolicies_ReturnsCatalog`, `GetPolicy_WithKnownCode_ReturnsPolicy`, `GetPolicy_WithUnknownCode_ReturnsNull` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)