### PR TITLE
docs: V11 — ADR 0001 (policies) + design doc + README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ Role-Based Access Control (RBAC) system for Andy applications.
 
 - **Role-Based Access Control** - Hierarchical roles with permission inheritance
 - **Fine-Grained Permissions** - Resource-level and instance-level permissions
+- **Policies** - Execution-time risk profiles (`read-only`, `high-risk`, `sandboxed`, `no-prod`, `draft-only`, `write-branch`) governing agent actions, gates, and retention
 - **Multi-Application Support** - Single RBAC server for multiple applications
 - **Team Management** - Organize users into teams with shared permissions
 - **gRPC and REST APIs** - High-performance permission checking
 - **ASP.NET Core Integration** - Authorization handlers and policy providers
 - **Caching** - In-memory caching for fast permission lookups
 - **MCP Support** - Model Context Protocol tools for AI assistants
+- **CLI** - `andy-rbac` for managing applications, roles, teams, users, and policies
 
 ## Quick Start
 
@@ -120,6 +122,56 @@ Examples:
 - `/api/roles` - Role management
 - `/api/subjects` - User/subject management
 - `/api/teams` - Team management
+- `/api/policies` - Policy catalog (Epic V — see [docs/policies.md](docs/policies.md))
+
+## Policies
+
+A **policy** is a named risk profile that downstream services (andy-tasks, andy-docs, Conductor) consume to decide auto-gating, retention, and action enforcement. Six stock policies ship pre-seeded (`read-only`, `write-branch`, `sandboxed`, `no-prod`, `high-risk`, `draft-only`); tenants may register additional policies via `POST /api/policies`.
+
+See **[docs/policies.md](docs/policies.md)** for the full catalog, rule key reference, event taxonomy, and FAQ. The design rationale is captured in **[ADR 0001 — Policies as first-class catalog rows](docs/adr/0001-policies.md)**.
+
+## CLI
+
+The `andy-rbac` CLI (`src/Andy.Rbac.Cli`) wraps the REST API for terminal-based admin and agent automation:
+
+```bash
+# Applications, roles, teams, users
+andy-rbac app list
+andy-rbac role list --application andy-tasks
+andy-rbac team list
+andy-rbac user search jane
+
+# Policies (Epic V)
+andy-rbac policy list                       # six stock policies + tenant overrides
+andy-rbac policy list --criticality High    # filter by criticality
+andy-rbac policy get high-risk              # full rule body for a policy
+
+# Permission checks
+andy-rbac check permission user-123 andy-tasks:goal:read
+
+# Output formats: --output table (default) | json | csv
+```
+
+Global flags: `--api-url` / `-u` (env `ANDY_RBAC_URL`), `--api-key` / `-k` (env `ANDY_RBAC_API_KEY`), `--output` / `-o`.
+
+## MCP Tools
+
+The `andy-rbac` API exposes MCP tools for AI assistants. Read-only tools cover permission checks and the Policy catalog; write tools cover application/role/team/user management.
+
+```
+# Permission checks
+CheckPermission, GetUserPermissions, GetUserRoles
+
+# Catalog reads
+ListApplications, GetApplication, ListRoles, ListTeams, SearchUsers, GetUser
+ListPolicies, GetPolicy
+
+# Mutations (admin-only paths)
+CreateApplication, CreateRole, AssignRoleToUser, RevokeRoleFromUser,
+CreateTeam, AddUserToTeam, AssignRoleToTeam, CreateUser
+```
+
+Policy mutations (`POST` / `PUT` / `DELETE`) are intentionally not surfaced via MCP — they stay on the REST surface so admin authorization paths don't move through tool calls.
 
 ## Testing
 

--- a/docs/adr/0001-policies.md
+++ b/docs/adr/0001-policies.md
@@ -1,0 +1,113 @@
+# ADR 0001 — Policies as first-class catalog rows
+
+- **Status:** Accepted
+- **Date:** 2026-05-08
+- **Deciders:** Sami Ben Grine
+- **Scope:** andy-rbac (catalog) plus every Andy service that consumes policy decisions: andy-tasks (delegation contracts, auto-gating, retention), andy-docs (archive tier), Conductor (`ActionBus` enforcement).
+
+## Context
+
+andy-rbac already models *who can do what* via roles and permissions — RBAC in the classical sense. That answers the question "is this caller allowed to invoke this endpoint?" but it does not answer the orthogonal question "under what risk profile may an agent execute this task?".
+
+The simulator (`simulator/app.js`) treated this second question as a separate vocabulary — six named **policies** (`read-only`, `write-branch`, `sandboxed`, `no-prod`, `high-risk`, `draft-only`) that bind to delegation contracts, action-bus invocations, and approval gates. Reusing the existing `Permission` table for this would conflate two unrelated concerns: *authorization* (does this principal have rights?) and *risk gating* (how much oversight does this action require?).
+
+Downstream services need a stable cross-service identifier. andy-tasks already stores `Goal.PolicyId` and `DelegationContract.PolicyId` as `varchar(64)` strings. andy-docs's archive tier resolution and andy-tasks's retention sweeper both depend on policy lookup. Without a Policy entity in andy-rbac, every consumer either hardcodes the six names or maintains its own catalog — both of which drift.
+
+## Decision
+
+We model `Policy` as a first-class entity in andy-rbac, separate from `Role` and `Permission`, with the following shape:
+
+```csharp
+class Policy {
+  Guid Id;                          // storage key; NOT the cross-service identifier
+  string Code;                      // unique slug, e.g. "high-risk" — the cross-service id
+  string Name;                      // display name
+  PolicyCriticality Criticality;    // Low | Medium | High | Critical
+  Dictionary<string,object>? Rules; // jsonb on Postgres / TEXT on SQLite
+  string? Description;
+  bool IsSystem;                    // stock policies cannot be edited or deleted
+  DateTimeOffset CreatedAt, UpdatedAt;
+}
+```
+
+### 1. Identity is by `Code`, not `Id`.
+
+Cross-service references (`Goal.PolicyId`, `DelegationContract.PolicyId`, archive-tier resolution, retention map keys) all use the stable `Code` string. The `Guid Id` is the storage primary key and the wire identifier in events (`andy.rbac.events.policy.{policy_id}.{kind}`), but never the cross-service reference. This keeps codes human-readable in DB diffs, in logs, and in the simulator vocabulary; the Guid is an internal detail.
+
+### 2. Rules are a free-form JSON dictionary, not a typed schema.
+
+Each consumer picks the keys it understands. Stable keys defined as of 2026-05-08:
+
+| Key | Type | Consumer | Meaning |
+|---|---|---|---|
+| `requirePreGate` | bool | andy-tasks AC3 | emit pre-execution approval gate |
+| `requirePostGate` | bool | andy-tasks AC3 | emit post-execution approval gate |
+| `blocksDeployTools` | bool | andy-tasks AC3 / Conductor V5 | reject deploy-class tasks under this policy |
+| `retentionDays` | int | andy-tasks AD4 | row retention for `agent_runs`, `task_events`, `agent_action_log` |
+| `archiveTier` | string | andy-tasks AD3 / andy-docs AJ | archive tier (`default` / `medium` / `high`) for blob retention |
+
+A typed Rules schema was considered and rejected. The set of keys grows as new consumers join (Epic AC, AD, AI, future). Rev'ing the schema across four repos every time a key lands would block on coordination overhead. The current shape lets each consumer ship its keys in lockstep with its own epic. We will revisit if the key surface stabilises.
+
+### 3. Stock policies are seeded with `IsSystem = true`.
+
+The six simulator policies are seeded by `DataSeeder.SeedStockPoliciesAsync` and flagged `IsSystem`. Tenants may register additional non-system policies via `POST /api/policies`. `IsSystem` rows reject `PUT` and `DELETE` with 400; this is a tracker-level immutability guarantee, not a database constraint, but the constraint is enforced consistently in `PolicyService`.
+
+### 4. Mutations stage transactional outbox events.
+
+`PolicyService.CreateAsync` / `UpdateAsync` / `DeleteAsync` call `IRbacEventPublisher.Policy{Created,Updated,Deleted}` on the same `RbacDbContext` as the domain row. The transactional outbox pattern from `andy-tasks/docs/adr/0001-messaging.md` applies unchanged: domain row + outbox row commit atomically; `OutboxDispatcher` drains to NATS at-least-once.
+
+Subjects follow the AL3 scheme:
+
+```
+andy.rbac.events.policy.{policy_id}.created
+andy.rbac.events.policy.{policy_id}.updated
+andy.rbac.events.policy.{policy_id}.deleted
+```
+
+`{policy_id}` is the Guid (stable wire identifier); the payload includes both `PolicyId` and `Code` so consumers can resolve either way.
+
+### 5. Read access is broadened; write access is admin-only.
+
+`GET /api/policies` and `GET /api/policies/{id|by-code}` require any authenticated caller. They are also surfaced as MCP tools (V7 — `ListPolicies`, `GetPolicy`) so agent contexts can resolve policies. Write paths (`POST` / `PUT` / `DELETE`) are not surfaced via MCP; the REST endpoints stay behind the admin auth path so policy mutations never travel through a tool call.
+
+## Consequences
+
+### Positive
+- Cross-service consumers (andy-tasks AC3, AD4, AD7; andy-docs RetentionCascadeWorker) gain a single source of truth for policy state.
+- Adding a new rule key is a one-side change in the consumer; no schema migration in andy-rbac.
+- The simulator vocabulary (`read-only`, `high-risk`, …) is preserved verbatim as `Code` values, so old documentation stays accurate.
+
+### Negative
+- The free-form `Rules` dictionary makes typos ("require_pre_gate" vs "requirePreGate") fail silently at the consumer rather than at write time. We accept this in exchange for schema-rev velocity; consumer-side tests catch typos in practice.
+- `Code` is the cross-service identifier but `Id` is what appears in NATS subjects. Consumers must look up by `Code` after receiving an event; they cannot subscribe to `andy.rbac.events.policy.high-risk.>` directly.
+
+### Neutral
+- The Policy table is small (six stock rows + tenant overrides) — there is no scale concern in the next two years.
+- `IsSystem` enforcement is at the service layer, not the DB layer. Bypassing it requires writing raw SQL against the DB; that is consistent with how the rest of the andy-rbac system policies (admin/editor/viewer roles) work.
+
+## Alternatives considered
+
+- **Reuse the `Permission` table.** Rejected — conflates authorization with risk gating and forces every consumer to query through the permission evaluator just to ask "what's the retention for this run?".
+- **Open Policy Agent (OPA) / Rego.** Rejected — the rule surface is small and shipping an embedded OPA evaluator alongside every consumer is operational overhead far in excess of what the rule shape needs. Revisit if rule complexity grows past simple key/value pairs.
+- **Server-side rule evaluation.** Rejected for now. Each consumer makes its own decisions from the rule dict because the consumers are diverse (auto-gating in andy-tasks, retention in andy-tasks, archive tier in andy-docs, action enforcement in Conductor). A central evaluator would either need a universal rule language (see OPA above) or a fan-out RPC per decision point. Both are heavier than the value.
+- **Snapshot rules onto the `Goal` / `DelegationContract`.** Adopted as a parallel pattern in andy-tasks AD2a (`PolicySnapshotJson`). The Policy entity is the source of truth; the snapshot is a per-run frozen copy so policy edits don't retroactively change in-flight runs. AD2a complements this ADR; it doesn't replace it.
+
+## Phased rollout
+
+1. **V1–V3 (this ADR's scope)** — entity, seed, REST endpoints, `IRbacEventPublisher` un-stub. ✅ shipped 2026-05-08 (PR #66).
+2. **V7** — MCP tools `policy.list` / `policy.get`. ✅ shipped 2026-05-08 (PR #67).
+3. **V8** — `andy-rbac policy {list,get}` CLI subcommand. ✅ shipped 2026-05-08 (PR #68).
+4. **V11** — this ADR + design doc + README. (current PR.)
+5. **V5** (rivoli-ai/conductor) — `ActionBus` enforcement hook reads policy on every Action invocation.
+6. **V6** — side-effects contract: andy-tasks AC3 (auto-gating), AD4/AD7 (retention) consume `Rules`.
+7. **AO** — cross-service end-to-end flow tests.
+
+## References
+
+- `simulator/app.js` — original Policies tab with the six-policy catalog.
+- `andy-tasks/docs/adr/0001-messaging.md` — transactional outbox + NATS subject taxonomy this ADR builds on.
+- rivoli-ai/andy-rbac#10 — Epic V parent issue.
+- rivoli-ai/andy-rbac#66 / #67 / #68 — PRs implementing V1–V3, V7, V8.
+- rivoli-ai/andy-tasks#57 — AC3 auto-gating consumer.
+- rivoli-ai/andy-tasks#73 — AD4 retention consumer.
+- rivoli-ai/andy-tasks#77 — AD7 critical-flag consumer.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,132 @@
+# Policies
+
+andy-rbac models two orthogonal concerns:
+
+- **Permissions** — *who can call what?* The classical RBAC model (subjects → roles → permissions).
+- **Policies** — *under what risk profile may an agent execute this work?*
+
+This document covers the second. For the first, see the README's *Permission Format* section.
+
+## Why policies exist
+
+Permissions answer "is this caller authorized?" Policies answer "how much oversight does this action require?". The two are independent: an admin (with every permission) running a task tagged `high-risk` still gets pre- and post-execution approval gates; a service account (with no admin permissions) running a `read-only` task hits no gates at all.
+
+A policy is a named risk profile with a small bundle of rules attached. Consumers (andy-tasks auto-gating, andy-tasks retention, andy-docs archive tier, Conductor `ActionBus`) read the rules and decide what to do.
+
+## Stock catalog
+
+Six policies are seeded as `IsSystem` rows at first boot:
+
+| Code | Criticality | Pre-gate | Post-gate | Blocks deploy | Row retention | Archive tier | Use when… |
+|---|---|---|---|---|---|---|---|
+| `read-only` | Low | — | — | — | 30 d | default | Agent reads repo state but never mutates anything. |
+| `write-branch` | Low | — | — | — | 30 d | default | Agent commits and pushes to non-default branches only. |
+| `sandboxed` | Medium | — | — | — | 30 d | default | Agent runs in an isolated sandbox; no external network or production access. |
+| `no-prod` | High | ✓ | — | ✓ | 365 d | medium | Pre-execution gate on any deploy-class task; blocks production-touching tools. |
+| `high-risk` | Critical | ✓ | ✓ | — | 2555 d (~7 y) | high | Pre + post execution gates on every task; full action-log retention. |
+| `draft-only` | Medium | — | ✓ | — | 30 d | default | Post-execution gate on publishable artifacts; outputs marked draft until reviewed. |
+
+System policies cannot be edited or deleted via the REST API (`PUT` / `DELETE` return 400). To change stock policy behaviour you change `DataSeeder.SeedStockPoliciesAsync` and ship a migration.
+
+## Rule keys
+
+`Policy.Rules` is a free-form dictionary persisted as `jsonb` on Postgres and `TEXT` on SQLite. Stable keys defined as of 2026-05-08:
+
+| Key | Type | Consumer | Default | Meaning |
+|---|---|---|---|---|
+| `requirePreGate` | bool | andy-tasks AC3 | false | Emit a pre-execution `ApprovalGate` row when a task with this policy is created. |
+| `requirePostGate` | bool | andy-tasks AC3 | false | Emit a post-execution `ApprovalGate` row when a task with this policy is verified. |
+| `blocksDeployTools` | bool | andy-tasks AC3 / Conductor V5 | false | Reject task creation when `DelegationContract.ToolsAllowed` contains deploy-class tools (`deploy`, `kubectl`, …). |
+| `retentionDays` | int | andy-tasks AD4 | 30 | Days before the retention sweeper hard-deletes `agent_runs`, `task_events`, `agent_action_log`. |
+| `archiveTier` | string | andy-tasks AD3 / andy-docs AJ | `"default"` | Archive tier (`default` / `medium` / `high`) governing andy-docs blob retention. |
+
+**Adding a rule key**: introduce it in your consumer, document it here, and ship a follow-up commit that sets the key on the relevant stock policies in `DataSeeder.SeedStockPoliciesAsync`. No andy-rbac schema migration is needed — the column is `jsonb`.
+
+**Typo handling**: unknown keys are ignored silently by consumers. Misspelt keys (e.g. `require_pre_gate` instead of `requirePreGate`) won't break anything, they just won't take effect. Consumer-side unit tests catch typos in practice.
+
+## Authoring a tenant policy
+
+Stock policies cover the common cases. To register a tenant-specific policy:
+
+```bash
+curl -X POST https://rbac.example.com/api/policies \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "code": "tenant-financial-data",
+    "name": "Tenant — financial data",
+    "criticality": "Critical",
+    "description": "Financial data domain — requires double-sign-off and 7-year retention.",
+    "rules": {
+      "requirePreGate": true,
+      "requirePostGate": true,
+      "retentionDays": 2555,
+      "archiveTier": "high"
+    }
+  }'
+```
+
+Or via CLI:
+
+```bash
+andy-rbac policy list                           # see what's there
+andy-rbac policy get high-risk                  # inspect the stock high-risk policy as a template
+# (write paths via REST or admin UI; the CLI list/get surface is read-only.)
+```
+
+## Event taxonomy
+
+Mutations emit on the `andy.rbac.events.policy.*` subject family per ADR-0001 (subject scheme):
+
+```
+andy.rbac.events.policy.{policy_id}.created
+andy.rbac.events.policy.{policy_id}.updated
+andy.rbac.events.policy.{policy_id}.deleted
+```
+
+`{policy_id}` is the policy's `Guid Id`. Payloads include both `PolicyId` and `Code` so consumers can resolve either way.
+
+Consumers subscribe wildcard:
+
+```csharp
+await bus.SubscribeAsync("andy.rbac.events.policy.>", handler, ct);
+```
+
+Typical reactions:
+
+- **andy-tasks PDP cache** invalidates a cached `Policy` on `*.updated` / `*.deleted`.
+- **andy-tasks AC3** re-evaluates open auto-gates if a policy's `requirePreGate` / `requirePostGate` flips.
+- **andy-tasks AD4a** propagates retention changes to the andy-docs archive tier when `retentionDays` or `archiveTier` changes.
+
+## Resolving a policy at runtime
+
+andy-tasks and andy-docs both look up policies by `Code`:
+
+```csharp
+// andy-tasks: resolve the policy named on a Goal
+var policy = await rbacClient.GetPolicyByCodeAsync(goal.PolicyId, ct);
+var requiresPreGate = policy.Rules?.GetValueOrDefault("requirePreGate") as bool? ?? false;
+```
+
+The PDP-cache pattern (cache by `Code`, invalidate on `andy.rbac.events.policy.*.updated`) is the recommended consumer side. See `andy-tasks/docs/adr/0001-messaging.md` §6 for the cache invalidation protocol.
+
+## FAQ
+
+**Q: Why was my action denied?**
+The denying consumer (Conductor `ActionBus`, andy-tasks `AutoGatingPolicyEvaluator`) logs the policy code and the rule key that triggered the deny. Look at the corresponding `RbacAuditLog` row or task-event payload — both record the policy `Code`, the matched rule, and the input that triggered it.
+
+**Q: Can I downgrade a `high-risk` policy on a finished run?**
+No. Policy state at run-creation time is snapshotted into `PolicySnapshotJson` (andy-tasks AD2a). Editing the policy doesn't retroactively affect frozen snapshots. The retention sweeper reads the snapshot, not the live policy.
+
+**Q: How do I extend retention on an existing run?**
+`AppSettings.Audit.RetentionOverrides` (per-tenant). Override always extends, never shortens. To shorten retention you need an admin-signed `RetentionDecreaseApproval` per AD4 §"Reconciliation update (2026-04-20)".
+
+**Q: Is the policy catalog the same across deployments?**
+The six stock policies are seeded everywhere. Tenant policies live in each deployment's RBAC database. There is no global policy registry across tenants — each `andy-rbac` instance owns its catalog.
+
+## See also
+
+- [ADR 0001 — Policies as first-class catalog rows](adr/0001-policies.md)
+- `andy-tasks/docs/adr/0001-messaging.md` — outbox + subject taxonomy
+- rivoli-ai/andy-rbac#10 — Epic V parent issue
+- README *Quick Start* + *API Endpoints*


### PR DESCRIPTION
## Summary
- Three docs deliverables completing Epic V: first ADR in this repo, long-form design/operator doc, and README updates surfacing Policies + CLI + MCP.
- Closes rivoli-ai/andy-rbac#28.

## What ships
- **`docs/adr/0001-policies.md`** — first ADR in andy-rbac. Captures: why Policy is a separate entity from Role/Permission, why cross-service identity is by `Code` not `Id`, the free-form `Rules` dictionary tradeoff, transactional-outbox reuse, `IsSystem` semantics, phased rollout linking to PRs #66 / #67 / #68.
- **`docs/policies.md`** — operator doc. Stock catalog table (criticality × pre-gate × post-gate × blocks-deploy × row retention × archive tier), rule key reference (`requirePreGate`, `requirePostGate`, `blocksDeployTools`, `retentionDays`, `archiveTier`) with consumer mapping, tenant authoring example, event taxonomy, FAQ.
- **README updates** — Features bullet for Policies + CLI, `/api/policies` row under Management, new *Policies* + *CLI* + *MCP Tools* sections.

## Test plan
- [x] Build still green (no code changes).
- [x] Markdown renders cleanly on GitHub preview (verified locally).
- [ ] Cross-references resolve: `docs/policies.md` → `docs/adr/0001-policies.md`, README → both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)