### PR TITLE
AL4: emit retention_changed events from PolicyService

### DIFF
--- a/src/Andy.Rbac.Api/Services/PolicyService.cs
+++ b/src/Andy.Rbac.Api/Services/PolicyService.cs
@@ -55,6 +55,7 @@ public class PolicyService : IPolicyService
         if (await _db.Policies.AnyAsync(p => p.Code == request.Code, ct))
             throw new InvalidOperationException($"Policy with code '{request.Code}' already exists");
 
+        var now = DateTimeOffset.UtcNow;
         var policy = new Policy
         {
             Id = Guid.NewGuid(),
@@ -64,8 +65,8 @@ public class PolicyService : IPolicyService
             Rules = request.Rules,
             Description = request.Description,
             IsSystem = false,
-            CreatedAt = DateTimeOffset.UtcNow,
-            UpdatedAt = DateTimeOffset.UtcNow,
+            CreatedAt = now,
+            UpdatedAt = now,
         };
 
         _db.Policies.Add(policy);
@@ -73,7 +74,25 @@ public class PolicyService : IPolicyService
             PolicyId: policy.Id,
             Code: policy.Code,
             ApplicationCode: null,
-            OccurredAt: DateTimeOffset.UtcNow));
+            OccurredAt: now));
+
+        // AL4 retention_changed at creation time: previous = null (no prior
+        // value), current = whatever the create request specified. Consumers
+        // (rivoli-ai/andy-tasks#74) treat null → value the same as
+        // value → value with the same idempotency semantics.
+        var newDays = ExtractRetentionDays(policy.Rules);
+        if (newDays.HasValue)
+        {
+            _events.RetentionChanged(new RetentionChanged(
+                PolicyId: policy.Id,
+                Code: policy.Code,
+                PreviousRetentionDays: null,
+                NewRetentionDays: newDays,
+                ChangeId: Guid.NewGuid().ToString("N"),
+                ChangedBy: null,
+                OccurredAt: now));
+        }
+
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation("Created policy {PolicyCode}", policy.Code);
@@ -89,17 +108,40 @@ public class PolicyService : IPolicyService
         if (policy.IsSystem)
             throw new InvalidOperationException("Cannot modify system policies");
 
+        // AL4: snapshot the previous retentionDays before mutating Rules so
+        // the RetentionChanged event can carry the old value.
+        var previousDays = ExtractRetentionDays(policy.Rules);
+
         if (request.Name != null) policy.Name = request.Name;
         if (request.Criticality.HasValue) policy.Criticality = request.Criticality.Value;
         if (request.Rules != null) policy.Rules = request.Rules;
         if (request.Description != null) policy.Description = request.Description;
-        policy.UpdatedAt = DateTimeOffset.UtcNow;
+        var now = DateTimeOffset.UtcNow;
+        policy.UpdatedAt = now;
 
         _events.PolicyUpdated(new PolicyUpdated(
             PolicyId: policy.Id,
             Code: policy.Code,
             ApplicationCode: null,
-            OccurredAt: DateTimeOffset.UtcNow));
+            OccurredAt: now));
+
+        // AL4: when the retentionDays rule changed (in either direction or
+        // null ↔ value), fire the specific retention_changed event so
+        // downstream consumers (rivoli-ai/andy-tasks#74) can cascade TTL
+        // updates without re-parsing the generic PolicyUpdated payload.
+        var newDays = ExtractRetentionDays(policy.Rules);
+        if (previousDays != newDays)
+        {
+            _events.RetentionChanged(new RetentionChanged(
+                PolicyId: policy.Id,
+                Code: policy.Code,
+                PreviousRetentionDays: previousDays,
+                NewRetentionDays: newDays,
+                ChangeId: Guid.NewGuid().ToString("N"),
+                ChangedBy: null,
+                OccurredAt: now));
+        }
+
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation("Updated policy {PolicyCode}", policy.Code);
@@ -126,6 +168,34 @@ public class PolicyService : IPolicyService
         _logger.LogInformation("Deleted policy {PolicyCode}", policy.Code);
 
         return true;
+    }
+
+    // AL4 helper: read the `retentionDays` integer off the policy's
+    // free-form Rules dictionary. Lives next to MapToDetail since both
+    // probe the same loosely-typed surface. Returns null when the rule
+    // is absent or unparseable so the caller can model "no retention
+    // configured" the same way as "consumer ignored the rule."
+    private static int? ExtractRetentionDays(Dictionary<string, object>? rules)
+    {
+        if (rules is null) return null;
+        // Stable key per Policy.cs:35 doc-comment.
+        if (!rules.TryGetValue("retentionDays", out var raw) || raw is null) return null;
+        // EF Core's Postgres jsonb conversion + the in-memory test path can
+        // return the same logical value under several CLR types — int,
+        // long, double, decimal, or System.Text.Json.JsonElement (when the
+        // dictionary was rehydrated from a JSON deserializer). Probe all
+        // so we don't silently drop the event.
+        return raw switch
+        {
+            int i => i,
+            long l when l >= int.MinValue && l <= int.MaxValue => (int)l,
+            double d when !double.IsNaN(d) && d >= int.MinValue && d <= int.MaxValue => (int)d,
+            decimal m when m >= int.MinValue && m <= int.MaxValue => (int)m,
+            System.Text.Json.JsonElement el => el.ValueKind == System.Text.Json.JsonValueKind.Number
+                && el.TryGetInt32(out var v) ? v : null,
+            string s when int.TryParse(s, out var v) => v,
+            _ => null,
+        };
     }
 
     private static PolicyDetail MapToDetail(Policy p) => new(

--- a/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
+++ b/src/Andy.Rbac.Infrastructure/Messaging/RbacEventPublisher.cs
@@ -47,6 +47,9 @@ public sealed class RbacEventPublisher : IRbacEventPublisher
     public void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null)
         => Stage($"{SubjectPrefix}.policy.{payload.PolicyId}.deleted", payload, headers);
 
+    public void RetentionChanged(RetentionChanged payload, MessageHeaders? headers = null)
+        => Stage($"{SubjectPrefix}.policy.{payload.PolicyId}.retention_changed", payload, headers);
+
     private void Stage(string subject, object payload, MessageHeaders? headers)
     {
         headers ??= MessageHeaders.NewRoot();

--- a/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
+++ b/src/Andy.Rbac/Messaging/Events/PolicyEvents.cs
@@ -30,3 +30,28 @@ public sealed record PolicyDeleted(
     string? ApplicationCode,
     DateTimeOffset OccurredAt
 );
+
+// AL4 RetentionChanged event. Fires from PolicyService.Update / Create
+// whenever the policy's `retentionDays` rule value changes (or moves
+// between null ↔ value). Subject:
+//   andy.rbac.events.policy.{policy_id}.retention_changed
+//
+// Carries before / after values so the consumer can decide direction
+// (increase vs decrease) without joining back to andy-rbac. `ChangeId`
+// is the idempotency token the consumer dedupes on; pre-generated here
+// so the same DB transaction that stages the outbox row carries the
+// id the bus will publish. AD4a's downstream cascade in andy-tasks +
+// andy-docs subscribes to this subject.
+//
+// Consumed by: rivoli-ai/andy-tasks#74 (AD4a — TTL cascade on agent_runs +
+// archive-tier mutation via andy-docs Epic AJ6).
+public sealed record RetentionChanged(
+    Guid PolicyId,
+    string Code,
+    int? PreviousRetentionDays,
+    int? NewRetentionDays,
+    string ChangeId,
+    string? ChangedBy,
+    DateTimeOffset OccurredAt,
+    int SchemaVersion = 1
+);

--- a/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
+++ b/src/Andy.Rbac/Messaging/IRbacEventPublisher.cs
@@ -14,7 +14,7 @@ namespace Andy.Rbac.Messaging;
 // Subject scheme (ADR 0001 + AL3):
 //   andy.rbac.events.role.{role_id}.{created|updated|deleted}
 //   andy.rbac.events.subject_role.{assignment_id}.{granted|revoked}
-//   andy.rbac.events.policy.{policy_id}.{created|updated|deleted}
+//   andy.rbac.events.policy.{policy_id}.{created|updated|deleted|retention_changed}
 public interface IRbacEventPublisher
 {
     void RoleCreated(RoleCreated payload, MessageHeaders? headers = null);
@@ -26,4 +26,8 @@ public interface IRbacEventPublisher
     void PolicyCreated(PolicyCreated payload, MessageHeaders? headers = null);
     void PolicyUpdated(PolicyUpdated payload, MessageHeaders? headers = null);
     void PolicyDeleted(PolicyDeleted payload, MessageHeaders? headers = null);
+    // AL4 — fires when the policy's `retentionDays` rule value changes
+    // (alongside the generic PolicyUpdated). Consumers (rivoli-ai/andy-tasks#74)
+    // dedupe on `ChangeId` for at-least-once delivery semantics.
+    void RetentionChanged(RetentionChanged payload, MessageHeaders? headers = null);
 }

--- a/tests/Andy.Rbac.Api.Tests/Services/PolicyServiceTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Services/PolicyServiceTests.cs
@@ -36,10 +36,15 @@ public class PolicyServiceTests
         var stored = await ctx.Policies.FirstAsync(p => p.Code == "tenant-policy");
         stored.Description.Should().Be("Tenant override");
 
+        // AL4: creation with `retentionDays` in Rules emits a paired
+        // retention_changed event alongside policy.created so AD4a's
+        // consumer can cascade TTLs without re-reading the policy.
         var outbox = await ctx.Outbox.ToListAsync();
-        outbox.Should().ContainSingle();
-        outbox[0].Subject.Should().StartWith("andy.rbac.events.policy.");
-        outbox[0].Subject.Should().EndWith(".created");
+        outbox.Should().HaveCount(2);
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".created"));
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".retention_changed"));
+        var retention = outbox.Single(e => e.Subject.EndsWith(".retention_changed"));
+        retention.Subject.Should().StartWith("andy.rbac.events.policy.");
     }
 
     [Fact]
@@ -159,5 +164,128 @@ public class PolicyServiceTests
         result.Policies.Should().HaveCount(2);
         result.Policies[0].Code.Should().Be("a");
         result.Policies[1].Code.Should().Be("z");
+    }
+
+    // ---- AL4 RetentionChanged ----------------------------------------
+
+    [Fact]
+    public async Task CreateAsync_WithoutRetentionDays_DoesNotEmitRetentionChanged()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        await service.CreateAsync(new CreatePolicyRequest(
+            Code: "no-retention",
+            Name: "No Retention",
+            Criticality: PolicyCriticality.Low,
+            Rules: new Dictionary<string, object> { ["requirePreGate"] = true }));
+
+        var outbox = await ctx.Outbox.ToListAsync();
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".created"));
+        outbox.Should().NotContain(e => e.Subject.EndsWith(".retention_changed"));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RetentionDaysChanged_EmitsRetentionChanged_WithBeforeAndAfter()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest(
+            Code: "rotate-up",
+            Name: "Rotate Up",
+            Criticality: PolicyCriticality.Medium,
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 30 }));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        await service.UpdateAsync(created.Policy.Id, new UpdatePolicyRequest(
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 365 }));
+
+        var outbox = await ctx.Outbox.ToListAsync();
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".retention_changed"));
+        var retention = outbox.Single(e => e.Subject.EndsWith(".retention_changed"));
+        retention.Subject.Should().Contain(created.Policy.Id.ToString());
+
+        // Payload carries before / after so the consumer can decide
+        // direction without re-fetching.
+        var payload = outbox.Single(e => e.Subject.EndsWith(".retention_changed")).PayloadJson;
+        payload.Should().Contain("\"previous_retention_days\":30");
+        payload.Should().Contain("\"new_retention_days\":365");
+        payload.Should().Contain("\"change_id\":");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RetentionDaysUnchanged_DoesNotEmitRetentionChanged()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest(
+            Code: "stable",
+            Name: "Stable",
+            Criticality: PolicyCriticality.Low,
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 30 }));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        // Same retentionDays — just renaming. No retention event.
+        await service.UpdateAsync(created.Policy.Id, new UpdatePolicyRequest(Name: "Stable Renamed"));
+
+        var outbox = await ctx.Outbox.ToListAsync();
+        outbox.Should().ContainSingle(e => e.Subject.EndsWith(".updated"));
+        outbox.Should().NotContain(e => e.Subject.EndsWith(".retention_changed"));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RetentionDaysCleared_EmitsRetentionChanged_WithNullNew()
+    {
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest(
+            Code: "clear-it",
+            Name: "Clear It",
+            Criticality: PolicyCriticality.Low,
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 30 }));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        // Replace Rules with one that has no retentionDays key.
+        await service.UpdateAsync(created.Policy.Id, new UpdatePolicyRequest(
+            Rules: new Dictionary<string, object> { ["requirePreGate"] = true }));
+
+        var payload = (await ctx.Outbox.FirstAsync(e => e.Subject.EndsWith(".retention_changed"))).PayloadJson;
+        payload.Should().Contain("\"previous_retention_days\":30");
+        // EventJson omits null fields on write (WhenWritingNull). The
+        // absence of `new_retention_days` is the wire form of "cleared";
+        // consumers treat missing the same as null.
+        payload.Should().NotContain("\"new_retention_days\"");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RetentionDaysDecreased_EmitsEvent_WithoutBlockingPath()
+    {
+        // AL4 producer side emits decreases the same way as increases.
+        // The downstream consumer (rivoli-ai/andy-tasks#74) is responsible
+        // for the RetentionDecreaseApproval gate when that ships — andy-rbac
+        // simply records the operator's intent on the bus.
+        using var ctx = TestDbContextFactory.Create();
+        var service = new PolicyService(ctx, _loggerMock.Object, new RbacEventPublisher(ctx));
+
+        var created = await service.CreateAsync(new CreatePolicyRequest(
+            Code: "rotate-down",
+            Name: "Rotate Down",
+            Criticality: PolicyCriticality.Medium,
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 2555 }));
+        ctx.Outbox.RemoveRange(ctx.Outbox);
+        await ctx.SaveChangesAsync();
+
+        await service.UpdateAsync(created.Policy.Id, new UpdatePolicyRequest(
+            Rules: new Dictionary<string, object> { ["retentionDays"] = 365 }));
+
+        var payload = (await ctx.Outbox.FirstAsync(e => e.Subject.EndsWith(".retention_changed"))).PayloadJson;
+        payload.Should().Contain("\"previous_retention_days\":2555");
+        payload.Should().Contain("\"new_retention_days\":365");
     }
 }


### PR DESCRIPTION
## Summary

Adds the producer half of the retention-cascade pipeline that unblocks [rivoli-ai/andy-tasks#74](https://github.com/rivoli-ai/andy-tasks/issues/74) (AD4a — TTL cascade on `agent_runs` + andy-docs archive-tier mutation). When a policy's `retentionDays` rule value changes, `PolicyService` stages a `RetentionChanged` outbox row alongside the generic `PolicyUpdated` / `PolicyCreated` event so downstream consumers can narrow-subscribe to retention deltas without re-parsing the broad-payload event.

## What ships

- **`RetentionChanged` event record** carrying:
  - `PolicyId`, `Code` — pointer fields
  - `PreviousRetentionDays`, `NewRetentionDays` — `int?` before / after (null ↔ value transitions modeled the same as value ↔ value)
  - `ChangeId` — operator-supplied idempotency token (fresh Guid hex for now; AD4a's consumer dedupes by `(policy_id, change_id)`)
  - `ChangedBy` — null today; will carry the actor once Subject/auth context flows into `PolicyService`
  - `OccurredAt`, `SchemaVersion = 1`
- **`IRbacEventPublisher.RetentionChanged(...)`** — subject `andy.rbac.events.policy.{policy_id}.retention_changed`.
- **`PolicyService.UpdateAsync`** snapshots the previous `retentionDays` from `Rules` before applying the request, then compares to the post-update value and emits when they differ (any direction, including null ↔ value).
- **`PolicyService.CreateAsync`** emits the event when the create request carries a `retentionDays` rule (previous = null, current = value).
- **`ExtractRetentionDays`** handles the loose-typed `Rules` dictionary defensively — int / long / double / decimal / `JsonElement` / string all round-trip back to `int?` cleanly.

## Decrease direction

The producer has no special handling for retention *decreases*. Per the [AD4 reconciliation note in rivoli-ai/andy-tasks#74](https://github.com/rivoli-ai/andy-tasks/issues/74#issue-spec-body), the decrease-approval gate lives on the consumer (AD4a validates `decrease_approval_id` against a future `RetentionDecreaseApproval` entity before applying the cascade). andy-rbac just records the operator's intent on the bus — the consumer decides what to do with it.

## Test plan

- [x] `dotnet build` — zero warnings.
- [x] `dotnet format` — clean on changed files (pre-existing whitespace in `RegistrationManifest.cs` left untouched).
- [x] `dotnet test` — **419 unit + 8 contract = 427 passed**.
- [x] Updated `CreateAsync_PersistsPolicyAndStagesOutbox` to assert both `.created` AND `.retention_changed` outbox rows when the create request carries `retentionDays`.
- [x] 5 new tests:
  - `CreateAsync_WithoutRetentionDays_DoesNotEmitRetentionChanged`
  - `UpdateAsync_RetentionDaysChanged_EmitsRetentionChanged_WithBeforeAndAfter` — payload carries `previous_retention_days` + `new_retention_days` + `change_id`.
  - `UpdateAsync_RetentionDaysUnchanged_DoesNotEmitRetentionChanged` — renaming with same `Rules` → no event.
  - `UpdateAsync_RetentionDaysCleared_EmitsRetentionChanged_WithNullNew` — `EventJson` omits null fields, so the absent key IS the wire form of "cleared."
  - `UpdateAsync_RetentionDaysDecreased_EmitsEvent_WithoutBlockingPath` — decrease emits the same as increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)