### PR TITLE
fix: embedded-mode failures — SQLite DateTimeOffset ORDER BY + JwtBearer issuer

### DIFF
--- a/src/Andy.Rbac.Api/Program.cs
+++ b/src/Andy.Rbac.Api/Program.cs
@@ -115,9 +115,20 @@ var andyAuthAuthority = builder.Configuration["AndyAuth:Authority"]
 builder.Services.AddAuthentication("Bearer")
     .AddJwtBearer("Bearer", options =>
     {
-        options.Authority = builder.Configuration["Auth:Authority"];
-        options.Audience = builder.Configuration["Auth:Audience"];
-        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        // Match the fallback chain used by `andyAuthAuthority` above
+        // (AndyAuth:Authority → Auth:Authority). Reading only
+        // `Auth:Authority` here left JwtBearer's Authority null when the
+        // env var was passed as `AndyAuth__Authority` (Conductor's
+        // embedded launcher), and the resulting JWT validation failed with
+        // `IDX10204: ValidIssuer is null or whitespace` on every request —
+        // andy-rbac silently 401'd every authenticated downstream call
+        // (and so every Conductor panel that depends on RBAC checks).
+        options.Authority = andyAuthAuthority;
+        options.Audience = builder.Configuration["AndyAuth:Audience"]
+            ?? builder.Configuration["Auth:Audience"];
+        options.RequireHttpsMetadata = builder.Configuration.GetValue<bool?>("AndyAuth:RequireHttpsMetadata")
+            ?? builder.Configuration.GetValue<bool?>("Auth:RequireHttpsMetadata")
+            ?? !builder.Environment.IsDevelopment();
         if (builder.Environment.IsDevelopment())
         {
             options.BackchannelHttpHandler = new HttpClientHandler

--- a/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
@@ -390,6 +390,32 @@ public class RbacDbContext : DbContext
             entity.Property(e => e.LastError).HasMaxLength(2000);
             entity.HasIndex(e => e.CorrelationId);
 
+            // SQLite cannot ORDER BY DateTimeOffset (it stores them as
+            // TEXT, which orders lexicographically, not chronologically).
+            // The dispatcher's hot path runs `OrderBy(e => e.CreatedAt)`
+            // so without this converter every tick throws
+            // NotSupportedException("SQLite does not support expressions
+            // of type 'DateTimeOffset' in ORDER BY clauses") and the
+            // OutboxDispatcher's ExecuteAsync catch-loop generates ~250 MB
+            // of stack-trace spam per minute. Store as UTC ticks (long)
+            // for SQLite only — Postgres handles DateTimeOffset natively
+            // via the `timestamp with time zone` migration column type.
+            // Round-trip is lossless because the entity always assigns
+            // DateTimeOffset.UtcNow on insert (see OutboxEntry.cs:37).
+            if (Database.IsSqlite())
+            {
+                entity.Property(e => e.CreatedAt)
+                    .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
+                entity.Property(e => e.PublishedAt)
+                    .HasConversion(
+                        v => v.HasValue ? v.Value.UtcTicks : (long?)null,
+                        v => v.HasValue ? new DateTimeOffset(v.Value, TimeSpan.Zero) : (DateTimeOffset?)null);
+                entity.Property(e => e.LastAttemptAt)
+                    .HasConversion(
+                        v => v.HasValue ? v.Value.UtcTicks : (long?)null,
+                        v => v.HasValue ? new DateTimeOffset(v.Value, TimeSpan.Zero) : (DateTimeOffset?)null);
+            }
+
             // Partial index on pending rows so the dispatcher's hot query
             // (WHERE PublishedAt IS NULL ORDER BY CreatedAt) scans only
             // the pending working set rather than the full audit history.


### PR DESCRIPTION
## Summary

Two unrelated bugs that combined to make andy-rbac unusable in Conductor's embedded mode (`ASPNETCORE_ENVIRONMENT=Embedded`, SQLite provider). Each one alone would have shipped andy-rbac broken; together they made every Conductor panel that touches RBAC fail with "Sign-in required" + 282 MB of log spam per minute.

## Bug 1: `OutboxDispatcher` LINQ fails under SQLite

`OutboxDispatcher.DrainOnceAsync` runs `Set<OutboxEntry>().OrderBy(e => e.CreatedAt)` every tick. SQLite stores `DateTimeOffset` as TEXT, which can't be `ORDER BY`'d chronologically, so EF Core throws `System.NotSupportedException: SQLite does not support expressions of type 'DateTimeOffset' in ORDER BY clauses`. `ExecuteAsync`'s catch-and-retry loop hammers this every poll interval → ~250 MB stack-trace spam per minute. Postgres is unaffected (uses `timestamp with time zone`).

Fix: SQLite-only `ValueConverter` on `OutboxEntry`'s three `DateTimeOffset` properties (`CreatedAt`, `PublishedAt`, `LastAttemptAt`) → `long` UTC ticks. Gated by `Database.IsSqlite()` so Postgres is untouched.

## Bug 2: JwtBearer reads `Auth:Authority` (null), not `AndyAuth:Authority`

`Program.cs:110` falls back `AndyAuth:Authority` → `Auth:Authority` correctly for the `andyAuthAuthority` local. But `Program.cs:118` then directly reads `Auth:Authority` for `options.Authority` — bypassing the fallback. Conductor passes the env var as `AndyAuth__Authority` (so `Auth:Authority` is always null in embedded mode), Authority ends up null, OIDC discovery never fires, `ValidIssuer` stays unset → every authenticated request fails with `IDX10204: ValidIssuer is null`. The 10 other ecosystem services all read `AndyAuth:Authority` directly; andy-rbac was the outlier.

Fix: use `andyAuthAuthority` directly. Same fallback chain applied to `Audience` and `RequireHttpsMetadata` for consistency.

## Verification

Reproduced both failures against Conductor's embedded launcher. Before:
- `andy-rbac.log` reached 282 MB in 60 seconds (LINQ + IDX10204 stack-trace spam)
- Every Conductor panel that hit RBAC surfaced `[TASKS-GOALS-LIST-001] Sign-in required` despite a valid Bearer token

After:
- `andy-rbac.log` stable at ~11 KB over 60s
- `grep -c "DateTimeOffset.*ORDER BY"` → 0
- `grep -c "IDX10204"` → 0
- Conductor panels load data through RBAC permission checks

## Test plan

- [x] `dotnet build src/Andy.Rbac.Api` clean (0 warnings, 0 errors)
- [x] Live verification under Conductor's embedded mode (above)
- [ ] Follow-up: automated regression tests for both branches alongside `RbacEventPublisherTests` — filed separately so this critical bundle isn't blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)