### PR TITLE
fix(seeder): bind manifest-declared admin role to all app permissions

### DIFF
--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -223,7 +223,94 @@ public static class DataSeeder
         // the latter need the Role rows queryable by code.
         await db.SaveChangesAsync(ct);
 
+        // Each manifest declares roles (admin / user / viewer) but does not
+        // declare which permissions those roles carry. Without an explicit
+        // binding the role rows exist but have zero `role_permissions`
+        // rows — every check that needs e.g. `andy-agents:agent:read`
+        // returns 403, including the test user even though they hold the
+        // admin role on the application.
+        //
+        // Convention: the application's `admin` role (manifest role with
+        // code `admin`) gets every permission for every resource type the
+        // manifest declares. Mirrors `SeedSuperAdminPermissionsAsync` but
+        // scoped to one application instead of cross-app. This is the
+        // minimum fix that lets the manifest-declared admin role act as
+        // the "full access" the manifest's role description claims.
+        //
+        // `user` / `viewer` roles are intentionally left unbound here —
+        // they need an explicit permission-list per role and that is a
+        // manifest-schema extension separate from this fix.
+        await SeedManifestAdminRolePermissionsAsync(db, manifests, logger, ct);
+
         await SeedTestUserRoleBindingsAsync(db, manifests, configuration, logger, ct);
+    }
+
+    /// <summary>
+    /// For every manifest-declared application, bind the application's
+    /// `admin` role to every permission for every resource type the
+    /// manifest declares. Idempotent — skips bindings that already exist.
+    /// </summary>
+    private static async Task SeedManifestAdminRolePermissionsAsync(
+        RbacDbContext db,
+        IReadOnlyList<RegistrationManifest> manifests,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var actions = await db.Actions.ToListAsync(ct);
+        if (actions.Count == 0) return;
+
+        foreach (var manifest in manifests)
+        {
+            if (manifest.Rbac is null) continue;
+
+            var app = await db.Applications.FirstOrDefaultAsync(a => a.Code == manifest.Rbac.ApplicationCode, ct);
+            if (app is null) continue;
+
+            var adminRole = await db.Roles.FirstOrDefaultAsync(r => r.ApplicationId == app.Id && r.Code == "admin", ct);
+            if (adminRole is null) continue;
+
+            var resourceTypes = await db.ResourceTypes.Where(rt => rt.ApplicationId == app.Id).ToListAsync(ct);
+            int bindingsAdded = 0;
+
+            foreach (var rt in resourceTypes)
+            {
+                foreach (var action in actions)
+                {
+                    var permission = await db.Permissions
+                        .FirstOrDefaultAsync(p => p.ResourceTypeId == rt.Id && p.ActionId == action.Id, ct);
+
+                    if (permission is null)
+                    {
+                        permission = new Permission
+                        {
+                            ResourceTypeId = rt.Id,
+                            ActionId = action.Id,
+                            Description = $"{action.Name} {rt.Name}"
+                        };
+                        db.Permissions.Add(permission);
+                        await db.SaveChangesAsync(ct);
+                    }
+
+                    if (!await db.RolePermissions.AnyAsync(rp => rp.RoleId == adminRole.Id && rp.PermissionId == permission.Id, ct))
+                    {
+                        db.RolePermissions.Add(new RolePermission
+                        {
+                            RoleId = adminRole.Id,
+                            PermissionId = permission.Id
+                        });
+                        bindingsAdded++;
+                    }
+                }
+            }
+
+            if (bindingsAdded > 0)
+            {
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation(
+                    "[manifest] Bound {Count} permissions to {App}'s admin role.",
+                    bindingsAdded, app.Code);
+            }
+        }
     }
 
     /// <summary>

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -372,6 +372,104 @@ public class DataSeederTests
     }
 
     [Fact]
+    public async Task SeedFromManifestsAsync_BindsAllPermissionsToManifestAdminRole()
+    {
+        // Regression for the empty-`role_permissions`-for-per-app-admin
+        // class of failure that surfaced on 2026-05-15: the manifest
+        // declares roles (admin / user / viewer) but no permission lists,
+        // and the seeder used to create the role rows without binding
+        // any permissions to them. Manifest-bound testUserRole then
+        // granted the test user the per-app admin role — which had zero
+        // permissions — so every `RequirePermission("X:Y:Z")` check on
+        // an authenticated controller returned 403. The companion
+        // failure was visible as `HTTP 403 GET /api/agents` after a
+        // fresh Conductor launch.
+        //
+        // Convention: after creating roles, the seeder binds every
+        // permission for every resource type the manifest declares to
+        // the application's `admin` role.
+        using var context = CreateContext();
+        // SeedAsync first so the global actions catalogue
+        // (read/write/delete/admin/...) exists.
+        await DataSeeder.SeedAsync(context);
+
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath);
+            await DataSeeder.SeedFromManifestsAsync(context, config, NullLogger.Instance);
+
+            var app = await context.Applications
+                .Include(a => a.Roles)
+                .Include(a => a.ResourceTypes)
+                .FirstOrDefaultAsync(a => a.Code == "andy-policies-test");
+            app.Should().NotBeNull("manifest must seed the application row");
+
+            var adminRole = app!.Roles.FirstOrDefault(r => r.Code == "admin");
+            adminRole.Should().NotBeNull("manifest declares an admin role");
+
+            var actions = await context.Actions.ToListAsync();
+            actions.Should().NotBeEmpty("SeedAsync seeds the global action catalogue");
+
+            // Every action × every manifest-declared resource type should
+            // be bound to the manifest's admin role. The manifest declares
+            // exactly one resource type (`policy`), so we expect one
+            // role_permission row per action.
+            var bindings = await context.RolePermissions
+                .Where(rp => rp.RoleId == adminRole!.Id)
+                .ToListAsync();
+            bindings.Count.Should().Be(
+                app.ResourceTypes.Count * actions.Count,
+                "admin role must be bound to every (resource type × action) permission for this application");
+
+            // Spot-check a specific permission to prove the binding shape
+            // is correct (and not just a side-effect count match).
+            var readAction = actions.First(a => a.Code == "read");
+            var policyType = app.ResourceTypes.First(rt => rt.Code == "policy");
+            var readPolicyPermission = await context.Permissions
+                .FirstOrDefaultAsync(p => p.ResourceTypeId == policyType.Id && p.ActionId == readAction.Id);
+            readPolicyPermission.Should().NotBeNull("permission rows are created during the binding pass");
+
+            var readPolicyBinding = bindings
+                .FirstOrDefault(rp => rp.PermissionId == readPolicyPermission!.Id);
+            readPolicyBinding.Should().NotBeNull(
+                "the admin role must hold the (policy, read) permission so RequirePermission(\"andy-policies-test:policy:read\") passes");
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_AdminRoleBinding_IsIdempotent()
+    {
+        // Same convention as above, but verifies the second call doesn't
+        // duplicate rows or grow the binding count. The seeder runs on
+        // every Conductor launch under the embedded-services path, so
+        // non-idempotent seed code accumulates indefinitely.
+        using var context = CreateContext();
+        await DataSeeder.SeedAsync(context);
+
+        var manifestPath = WriteTempManifest(SampleManifestWithTestUserRole);
+        try
+        {
+            var config = ConfigurationWithManifest(manifestPath);
+            await DataSeeder.SeedFromManifestsAsync(context, config, NullLogger.Instance);
+            var firstCount = await context.RolePermissions.CountAsync();
+
+            await DataSeeder.SeedFromManifestsAsync(context, config, NullLogger.Instance);
+            var secondCount = await context.RolePermissions.CountAsync();
+
+            secondCount.Should().Be(firstCount, "admin-role binding must be idempotent across re-seeds");
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
     public async Task SeedFromManifestsAsync_InProduction_SkipsTestUserRoleBinding()
     {
         using var context = CreateContext();


### PR DESCRIPTION
## Summary

Each Andy service ships a registration manifest declaring roles (admin / user / viewer) but no permission lists. `SeedFromManifestsAsync` created role rows without binding any permissions to them — so the per-app `admin` role had **zero** `role_permissions` entries, and any subject holding it (most notably the test user via `testUserRole: "admin"`) got denied every `RequirePermission(...)` check.

## Symptom

After a fresh launch of the Conductor embedded-services bundle:

```
$ curl /api/agents -H "Authorization: Bearer <test-user-token>"
HTTP/1.1 403 Forbidden
```

Same pattern for `/api/models`, `/api/policies`, `/api/tasks`. The Issues panel happened to work because its UI didn't gate on RBAC checks.

## Fix

Add a new convention to `SeedFromManifestsAsync`: after creating manifest-declared roles, bind the application's `admin` role to every permission for every resource type the manifest declares. Mirrors `SeedSuperAdminPermissionsAsync` but scoped per-application.

`user` / `viewer` roles are intentionally left unbound — they need explicit permission lists per role and that's a manifest-schema extension for a separate change.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~DataSeederTests"` — 20/20 pass (18 pre-existing + 2 new regression tests for the binding + idempotency)
- [x] `dotnet build` — clean
- [x] Will verify in vivo against Conductor's embedded launcher: `HTTP 403 GET /api/agents` should become `200` once this PR's binary is re-vendored

🤖 Generated with [Claude Code](https://claude.com/claude-code)