### PR TITLE
fix(sqlite): global DateTimeOffset converter — covers SubjectRole + audit logs

### DIFF
--- a/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
+++ b/src/Andy.Rbac.Infrastructure/Data/RbacDbContext.cs
@@ -37,6 +37,36 @@ public class RbacDbContext : DbContext
     // inside the same transaction; OutboxDispatcher drains them to NATS.
     public DbSet<OutboxEntry> Outbox => Set<OutboxEntry>();
 
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        base.ConfigureConventions(configurationBuilder);
+
+        // SQLite stores `DateTimeOffset` as TEXT, which orders
+        // lexicographically and breaks every WHERE/ORDER BY that compares
+        // a column to a `DateTimeOffset` value or asks "is this null or
+        // < now". The first round of this hit OutboxDispatcher's hot
+        // query (PR #72); the second round surfaced via
+        // `PermissionRepository.HasPermissionAsync` filtering
+        // `SubjectRole.ExpiresAt > now` — every `/api/check` call
+        // returned 500 under SQLite, which downstream service handlers
+        // then mapped to `Deny` so every authenticated controller
+        // returned 403.
+        //
+        // Bind a binary converter (`DateTimeOffset` <-> `long`) at the
+        // convention level so every DateTimeOffset column on every
+        // entity in this DbContext gets the same treatment. Avoids the
+        // whack-a-mole "I missed one" pattern. Postgres handles
+        // DateTimeOffset natively via `timestamp with time zone`, so the
+        // conversion is gated to SQLite only.
+        if (Database.IsSqlite())
+        {
+            configurationBuilder.Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder.Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
+    }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -390,31 +420,15 @@ public class RbacDbContext : DbContext
             entity.Property(e => e.LastError).HasMaxLength(2000);
             entity.HasIndex(e => e.CorrelationId);
 
-            // SQLite cannot ORDER BY DateTimeOffset (it stores them as
-            // TEXT, which orders lexicographically, not chronologically).
-            // The dispatcher's hot path runs `OrderBy(e => e.CreatedAt)`
-            // so without this converter every tick throws
-            // NotSupportedException("SQLite does not support expressions
-            // of type 'DateTimeOffset' in ORDER BY clauses") and the
-            // OutboxDispatcher's ExecuteAsync catch-loop generates ~250 MB
-            // of stack-trace spam per minute. Store as UTC ticks (long)
-            // for SQLite only — Postgres handles DateTimeOffset natively
-            // via the `timestamp with time zone` migration column type.
-            // Round-trip is lossless because the entity always assigns
-            // DateTimeOffset.UtcNow on insert (see OutboxEntry.cs:37).
-            if (Database.IsSqlite())
-            {
-                entity.Property(e => e.CreatedAt)
-                    .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero));
-                entity.Property(e => e.PublishedAt)
-                    .HasConversion(
-                        v => v.HasValue ? v.Value.UtcTicks : (long?)null,
-                        v => v.HasValue ? new DateTimeOffset(v.Value, TimeSpan.Zero) : (DateTimeOffset?)null);
-                entity.Property(e => e.LastAttemptAt)
-                    .HasConversion(
-                        v => v.HasValue ? v.Value.UtcTicks : (long?)null,
-                        v => v.HasValue ? new DateTimeOffset(v.Value, TimeSpan.Zero) : (DateTimeOffset?)null);
-            }
+            // SQLite cannot ORDER BY DateTimeOffset — the dispatcher's
+            // `OrderBy(e => e.CreatedAt)` hot path used to throw
+            // NotSupportedException every tick. The fix now lives at
+            // `ConfigureConventions` (above), which applies
+            // DateTimeOffsetToBinaryConverter to every DateTimeOffset
+            // property on every entity in this context. No per-entity
+            // configuration needed here. See andy-rbac#72 for the
+            // original OutboxEntry-only fix and #73 for the move to a
+            // global convention.
 
             // Partial index on pending rows so the dispatcher's hot query
             // (WHERE PublishedAt IS NULL ORDER BY CreatedAt) scans only


### PR DESCRIPTION
## Summary

PR #72 added a SQLite `DateTimeOffset` converter scoped to `OutboxEntry` only. The same SQLite limitation hit a second hot path: `PermissionRepository.HasPermissionAsync` filters `SubjectRole.ExpiresAt > now`, which can't be translated under SQLite. Every `POST /rbac/api/check` returned HTTP 500. Downstream services map 500 → Deny, so every authenticated controller returned 403 — even for the test user with correctly-seeded `admin` role bindings on every app (PR #73).

Replace the entity-scoped converter on `OutboxEntry` with a global `ConfigureConventions` override that binds `DateTimeOffsetToBinaryConverter` to every `DateTimeOffset` / `DateTimeOffset?` property on every entity in this DbContext. Same shape as the andy-agents fix in #174.

## Verification

Reproduced against Conductor's embedded launcher:

```
POST /rbac/api/check
{"subjectId":"00000000-...001","permission":"andy-agents:agent:read"}

→ before: HTTP 500 + LINQ stack trace on SubjectRole.ExpiresAt > now
→ after:  expected HTTP 200 + {"allowed": true} (will verify in-vivo post-merge)
```

Downstream symptom: `HTTP 403 GET /api/agents` despite the test user holding the `admin` role on `andy-agents` with all permissions bound (PR #73 chain).

## Test plan

- [x] `dotnet build src/Andy.Rbac.Api` — clean
- [x] `dotnet test --filter "FullyQualifiedName~DataSeederTests"` — 20/20 pass
- [x] `dotnet test --filter "FullyQualifiedName~PermissionRepository|PermissionEvaluator"` — 43/43 pass
- [ ] Follow-up: SQLite-specific regression test (existing tests use InMemory provider)
- [ ] In-vivo verification after re-vendor into Conductor

🤖 Generated with [Claude Code](https://claude.com/claude-code)