### PR TITLE
fix(#75): RbacHttpClient attaches an M2M Bearer via AddRbacClientWithM2M

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Andy ecosystem -->
+    <PackageVersion Include="Andy.Auth.M2MClient" Version="2026.5.13-rc.189" />
+
     <!-- ASP.NET Core -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Andy.Rbac.Client/Andy.Rbac.Client.csproj
+++ b/src/Andy.Rbac.Client/Andy.Rbac.Client.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Andy.Auth.M2MClient" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" />
     <PackageReference Include="Grpc.Net.Client" />

--- a/src/Andy.Rbac.Client/ServiceCollectionExtensions.cs
+++ b/src/Andy.Rbac.Client/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Andy.Auth.M2MClient;
 using Andy.Rbac.Abstractions;
 using Andy.Rbac.Configuration;
 using Andy.Rbac.DependencyInjection;
@@ -37,6 +38,74 @@ public static class ServiceCollectionExtensions
             client.BaseAddress = new Uri(options.ApiBaseUrl);
             client.Timeout = options.HttpClient.Timeout;
         })
+        .AddPolicyHandler((sp, _) =>
+        {
+            var options = sp.GetRequiredService<IOptions<RbacOptions>>().Value;
+            return GetRetryPolicy(options.HttpClient);
+        });
+
+        // Register IPermissionService as the client
+        services.AddScoped<IPermissionService>(sp => sp.GetRequiredService<IRbacClient>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the RBAC client AND <c>Andy.Auth.M2MClient</c>
+    /// infrastructure, then wires the outbound <see cref="RbacHttpClient"/>
+    /// through <see cref="ServiceBearerHandler"/> so every request to
+    /// <c>/api/Check</c> (and friends) carries an M2M-acquired Bearer.
+    ///
+    /// Before this overload existed, every consumer of
+    /// <see cref="IRbacClient"/> in the embedded-services setup called
+    /// the no-auth <see cref="AddRbacClient(IServiceCollection, IConfiguration)"/>
+    /// — the resulting <c>HttpClient</c> sent requests with no
+    /// Authorization header, andy-rbac's <c>[Authorize]</c> middleware
+    /// denied them, the proxy mapped that into <c>502 Bad Gateway</c>,
+    /// and downstream services' permission handlers (e.g.
+    /// <c>RbacPermissionHandler</c> in andy-agents) caught the exception
+    /// and returned <c>Deny</c>. Every Conductor panel that gated on
+    /// <c>[RequirePermission(...)]</c> surfaced 403. See
+    /// rivoli-ai/andy-rbac#75 for the full diagnosis.
+    ///
+    /// The host service's <c>AndyAuth</c> configuration section must
+    /// define <c>ClientId</c>, <c>ClientSecretEnvVar</c>, and either
+    /// <c>TokenEndpoint</c> or <c>Authority</c> — same wire-up
+    /// requirement as <c>AddAndySettingsClientWithM2M</c>.
+    ///
+    /// Idempotent — calling either overload after the other is safe.
+    /// </summary>
+    public static IServiceCollection AddRbacClientWithM2M(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Brings in IServiceTokenProvider (ClientCredentialsTokenProvider
+        // + a coalescing cache) and registers a hosted refresher.
+        services.AddAndyAuthM2M(configuration);
+
+        // Add core RBAC services
+        services.AddRbac(configuration);
+
+        // Register subject accessor
+        services.AddScoped<ICurrentSubjectAccessor, HttpContextSubjectAccessor>();
+
+        // The handler is transient/scoped via AddHttpMessageHandler;
+        // it pulls IServiceTokenProvider from the request-scoped DI
+        // container on every send so the cached token + 401-retry are
+        // honoured per-request.
+        services.AddTransient<ServiceBearerHandler>();
+
+        // Configure HTTP client with the bearer handler in the pipeline.
+        services.AddHttpClient<IRbacClient, RbacHttpClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<RbacOptions>>().Value;
+            if (string.IsNullOrEmpty(options.ApiBaseUrl))
+                throw new InvalidOperationException("RbacOptions.ApiBaseUrl must be configured");
+
+            client.BaseAddress = new Uri(options.ApiBaseUrl);
+            client.Timeout = options.HttpClient.Timeout;
+        })
+        .AddHttpMessageHandler<ServiceBearerHandler>()
         .AddPolicyHandler((sp, _) =>
         {
             var options = sp.GetRequiredService<IOptions<RbacOptions>>().Value;


### PR DESCRIPTION
## Summary

Closes #75.

`RbacHttpClient`'s `HttpClient` had no auth handler. Every consumer of `AddRbacClient(configuration)` sent `/api/Check` without an Authorization header → `[Authorize]` denied → proxy mapped 401→502 → downstream `RbacPermissionHandler` caught and returned `Deny` → every panel that gated on `[RequirePermission(...)]` surfaced 403.

Adds `AddRbacClientWithM2M(IServiceCollection, IConfiguration)` that wires `Andy.Auth.M2MClient`'s `ServiceBearerHandler` into the pipeline. Existing `AddRbacClient` overloads are unchanged (opt-in adoption).

## Test plan

- [x] `dotnet build src/Andy.Rbac.Client` clean
- [x] Existing callers compile unchanged
- [ ] Live in-vivo verification post-merge once a consumer service migrates (follow-up PR queued against andy-agents)

## Follow-up coordination

Each downstream service needs:

1. `Program.cs` switches `AddRbacClient(builder.Configuration)` → `AddRbacClientWithM2M(builder.Configuration)`
2. `appsettings*` define `AndyAuth:ClientId`, `AndyAuth:ClientSecretEnvVar`, `AndyAuth:TokenEndpoint` (or `Authority`)
3. The Conductor service config injects the matching env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)