### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd src/Andy.Rbac.Api
 dotnet run
 ```
 
-API runs at: **https://localhost:5001**
+API runs at: **https://localhost:5003**
 
 ## Project Structure
 

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -257,7 +257,7 @@ andy-rbac applications list
 andy-rbac roles assign --role admin --subject <id>
 andy-rbac users provision --provider andy-auth --external-id <id>
 andy-rbac teams create --code dev-team
-andy-rbac check --subject <id> --permission andy-docs:document:read
+andy-rbac check permission <user-id> andy-docs:document:read
 ```
 
 Thin wrapper over the REST API — useful for ops scripts and CI setup.
@@ -291,7 +291,7 @@ Optional client-side cache short-circuits repeat checks.
 
 | Port | Purpose |
 |------|---------|
-| 5001 / 7003 | RBAC API HTTPS (dev/docker) |
+| 5003 / 7003 | RBAC API HTTPS (dev/docker) |
 | 5180 | Blazor admin UI |
 | 5432 / 5433 | PostgreSQL |
 


### PR DESCRIPTION
## Summary

- Fix the API port in `README.md` and `docs/presentation.md`: the README claimed `https://localhost:5001`, but the canonical https port for andy-rbac is `5003` (see `config/registration.json` and `src/Andy.Rbac.Api/Properties/launchSettings.json`).
- Fix the CLI example in `docs/presentation.md` (`andy-rbac check --subject <id> --permission ...` is not what `Andy.Rbac.Cli/Commands/CheckCommands.cs` wires up — the actual form is `andy-rbac check permission <user> <permission>`, matching the rest of the docs).

## Test plan

- [ ] Run `andy-rbac check permission <user> <permission>` against a running server.
- [ ] Confirm the API listens on `5003` per `launchSettings.json`.