### PR TITLE
docs: refresh markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ dotnet add package Andy.Rbac.Client
 // Add to Program.cs
 builder.Services.AddRbacClient(options =>
 {
-    options.BaseUrl = "https://rbac-api.example.com";
+    options.ApiBaseUrl = "https://rbac-api.example.com";
     options.ApplicationCode = "my-app";
 });
 
@@ -112,8 +112,8 @@ Examples:
 ## API Endpoints
 
 ### Permission Checking
-- `POST /api/check/permission` - Check single permission
-- `POST /api/check/any-permission` - Check if user has any of the permissions
+- `POST /api/check` - Check single permission
+- `POST /api/check/any` - Check if user has any of the permissions
 - `GET /api/check/permissions/{subjectId}` - Get all permissions for a user
 - `GET /api/check/roles/{subjectId}` - Get all roles for a user
 

--- a/content/help/permissions.md
+++ b/content/help/permissions.md
@@ -37,10 +37,9 @@ Content-Type: application/json
 
 {
   "subjectId": "user-123",
-  "resourceType": "issue",
-  "action": "delete",
-  "resourceId": "issue-456"
+  "permission": "issues:issue:delete",
+  "resourceInstanceId": "issue-456"
 }
 ```
 
-The response returns `allowed: true` or `allowed: false`.
+The response returns `allowed: true` or `allowed: false` plus a `reason` string.

--- a/docs/help/overview.fr.md
+++ b/docs/help/overview.fr.md
@@ -12,7 +12,7 @@ Andy RBAC est le service de contrôle d'accès basé sur les rôles de l'écosys
 ## Ce qu'il fait
 
 - Maintient un catalogue versionné de rôles, de types de ressources et des permissions que chaque rôle accorde.
-- Évalue les vérifications de permission via `POST /api/v1/permissions/check` — la couture canonique que chaque autre service utilise pour l'autorisation.
+- Évalue les vérifications de permission via `POST /api/check` — la couture canonique que chaque autre service utilise pour l'autorisation.
 - Prend en charge l'héritage de rôles afin que les rôles dérivés se composent sans copier les listes de permissions.
 - Met en cache les évaluations récentes pour garder le chemin commun de vérification sous la milliseconde.
 - Expose un catalogue en lecture seule que l'interface Conductor utilise pour afficher les panneaux « ce que cet utilisateur peut faire ».

--- a/docs/help/overview.md
+++ b/docs/help/overview.md
@@ -12,7 +12,7 @@ Andy RBAC is the role-based access control service for the Andy ecosystem. It ow
 ## What it does
 
 - Maintains a versioned catalog of roles, resource types, and the permissions each role grants.
-- Evaluates permission checks via `POST /api/v1/permissions/check` — the canonical seam every other service uses for authorization.
+- Evaluates permission checks via `POST /api/check` — the canonical seam every other service uses for authorization.
 - Supports role inheritance so derived roles compose without copying permission lists.
 - Caches recent evaluations to keep the common-path check under a millisecond.
 - Surfaces a read-only catalog the Conductor UI uses to render "what can this user do" panels.

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -253,11 +253,12 @@ OIDC login via Andy Auth. Actions themselves are guarded by RBAC client checks (
 ## CLI (`Andy.Rbac.Cli`)
 
 ```bash
-andy-rbac applications list
-andy-rbac roles assign --role admin --subject <id>
-andy-rbac users provision --provider andy-auth --external-id <id>
-andy-rbac teams create --code dev-team
+andy-rbac app list
+andy-rbac role assign --role admin --subject <id>
+andy-rbac user provision --provider andy-auth --external-id <id>
+andy-rbac team create --code dev-team
 andy-rbac check permission <user-id> andy-docs:document:read
+andy-rbac policy list
 ```
 
 Thin wrapper over the REST API — useful for ops scripts and CI setup.
@@ -293,7 +294,7 @@ Optional client-side cache short-circuits repeat checks.
 |------|---------|
 | 5003 / 7003 | RBAC API HTTPS (dev/docker) |
 | 5180 | Blazor admin UI |
-| 5432 / 5433 | PostgreSQL |
+| 5432 / 7433 | PostgreSQL (in-container / host-published) |
 
 Key settings:
 
@@ -310,7 +311,7 @@ Key settings:
 
 `docker-compose.yml`:
 
-- `postgres:16-alpine` (port 5433)
+- `postgres:16-alpine` (host port 7433 → container 5432)
 - API (`7003:8443` / `7004:8080`)
 - Web (`5180:8443` / `5181:8080`)
 


### PR DESCRIPTION
## Summary
- Align permission-check endpoint references in the README, public help, and French help with the real surface (`POST /api/check`, `POST /api/check/any`).
- Fix the example request payload in `content/help/permissions.md` to match `CheckPermissionRequest` (`permission` + `resourceInstanceId`).
- Correct the `AddRbacClient` sample in the README to use `options.ApiBaseUrl` instead of the nonexistent `options.BaseUrl`.
- Update `docs/presentation.md`: PostgreSQL host port is `7433` per `docker-compose.yml` (not 5433); CLI command groups are singular (`app`, `role`, `user`, `team`) and `policy` is added.

## Test plan
- [ ] Reviewer reads diffs, confirms claims match current code/state
- [ ] No code changes — markdown-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)