### PR TITLE
[Feat] Seed RBAC subjects+grants for M2M service principals

### DIFF
--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -242,7 +242,131 @@ public static class DataSeeder
         // manifest-schema extension separate from this fix.
         await SeedManifestAdminRolePermissionsAsync(db, manifests, logger, ct);
 
+        // Must run AFTER admin-permission seeding: that step materialises a
+        // Permission row for every app's resourceType×action, so the
+        // cross-service permissions a service principal references already
+        // exist by the time we bind them here.
+        await SeedServicePrincipalGrantsAsync(db, manifests, logger, ct);
+
         await SeedTestUserRoleBindingsAsync(db, manifests, configuration, logger, ct);
+    }
+
+    /// <summary>
+    /// Provisions RBAC subjects + grants for service-to-service (M2M)
+    /// principals declared via <c>rbac.servicePrincipal</c> in a manifest.
+    /// andy-auth issues client_credentials tokens with <c>sub = clientId</c>
+    /// and no email claim, so <see cref="Middleware.EnsureSubjectMiddleware"/>
+    /// deliberately does NOT auto-provision them — without this seeding every
+    /// service-to-service <c>[RequirePermission]</c> call fails with
+    /// "Subject not found". For each declared principal we ensure a
+    /// <see cref="SubjectType.Service"/> subject, a cross-application
+    /// <c>service:{clientId}</c> role carrying exactly the declared
+    /// permissions (least privilege — no blanket service role), and the
+    /// subject→role assignment. Idempotent across restarts.
+    /// </summary>
+    public static async Task SeedServicePrincipalGrantsAsync(
+        RbacDbContext db,
+        IReadOnlyList<RegistrationManifest> manifests,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        foreach (var manifest in manifests)
+        {
+            var sp = manifest.Rbac?.ServicePrincipal;
+            if (sp is null
+                || string.IsNullOrWhiteSpace(sp.ClientId)
+                || sp.Permissions is null
+                || sp.Permissions.Length == 0)
+            {
+                continue;
+            }
+
+            // 1. The Service subject (sub == clientId on the M2M token).
+            var subject = await db.Subjects.FirstOrDefaultAsync(s => s.ExternalId == sp.ClientId, ct);
+            if (subject is null)
+            {
+                subject = new Subject
+                {
+                    ExternalId = sp.ClientId,
+                    Provider = "andy-auth",
+                    Type = SubjectType.Service,
+                    DisplayName = sp.ClientId,
+                    IsActive = true,
+                    LastSeenAt = DateTimeOffset.UtcNow,
+                };
+                db.Subjects.Add(subject);
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation("[manifest] Provisioned Service subject {ClientId}.", sp.ClientId);
+            }
+
+            // 2. A dedicated cross-application role (ApplicationId == null) that
+            //    carries only this principal's declared permissions.
+            var roleCode = $"service:{sp.ClientId}";
+            var role = await db.Roles.FirstOrDefaultAsync(r => r.Code == roleCode && r.ApplicationId == null, ct);
+            if (role is null)
+            {
+                role = new Role
+                {
+                    ApplicationId = null,
+                    Code = roleCode,
+                    Name = $"Service principal: {sp.ClientId}",
+                    Description = $"Cross-service permissions for the {sp.ClientId} M2M client.",
+                    IsSystem = true,
+                };
+                db.Roles.Add(role);
+                await db.SaveChangesAsync(ct);
+            }
+
+            // 3. Bind each fully-qualified "app:resourceType:action" permission.
+            var bound = 0;
+            foreach (var code in sp.Permissions)
+            {
+                var parts = code.Split(':');
+                if (parts.Length != 3)
+                {
+                    logger.LogWarning(
+                        "[manifest] Service principal {ClientId}: ignoring malformed permission '{Code}' (expected app:resourceType:action).",
+                        sp.ClientId, code);
+                    continue;
+                }
+
+                var permission = await db.Permissions.FirstOrDefaultAsync(p =>
+                    p.ResourceType.Application != null &&
+                    p.ResourceType.Application.Code == parts[0] &&
+                    p.ResourceType.Code == parts[1] &&
+                    p.Action.Code == parts[2], ct);
+
+                if (permission is null)
+                {
+                    logger.LogWarning(
+                        "[manifest] Service principal {ClientId}: permission '{Code}' not found — is the owning service's manifest seeded?",
+                        sp.ClientId, code);
+                    continue;
+                }
+
+                if (!await db.RolePermissions.AnyAsync(rp => rp.RoleId == role.Id && rp.PermissionId == permission.Id, ct))
+                {
+                    db.RolePermissions.Add(new RolePermission { RoleId = role.Id, PermissionId = permission.Id });
+                    bound++;
+                }
+            }
+            if (bound > 0) await db.SaveChangesAsync(ct);
+
+            // 4. The subject→role assignment (global, non-expiring).
+            if (!await db.SubjectRoles.AnyAsync(sr => sr.SubjectId == subject.Id && sr.RoleId == role.Id, ct))
+            {
+                db.SubjectRoles.Add(new SubjectRole
+                {
+                    SubjectId = subject.Id,
+                    RoleId = role.Id,
+                });
+                await db.SaveChangesAsync(ct);
+            }
+
+            logger.LogInformation(
+                "[manifest] Service principal {ClientId} bound to {Count} permission(s).",
+                sp.ClientId, sp.Permissions.Length);
+        }
     }
 
     /// <summary>

--- a/src/Andy.Rbac.Api/Data/RegistrationManifest.cs
+++ b/src/Andy.Rbac.Api/Data/RegistrationManifest.cs
@@ -34,7 +34,26 @@ public sealed record RegistrationRbacInfo(
     [property: JsonPropertyName("description")]     string? Description,
     [property: JsonPropertyName("resourceTypes")]   RegistrationResourceType[]? ResourceTypes,
     [property: JsonPropertyName("roles")]           RegistrationRole[]? Roles,
-    [property: JsonPropertyName("testUserRole")]    string? TestUserRole
+    [property: JsonPropertyName("testUserRole")]    string? TestUserRole,
+    [property: JsonPropertyName("servicePrincipal")] RegistrationServicePrincipal? ServicePrincipal
+);
+
+/// <summary>
+/// Declares the cross-service permissions a service's machine-to-machine
+/// (client_credentials) principal needs. andy-auth issues these tokens with
+/// <c>sub = clientId</c> and no <c>email</c> claim, so they are NOT auto-
+/// provisioned as RBAC subjects (see EnsureSubjectMiddleware). Without an
+/// explicit grant every service-to-service <c>[RequirePermission]</c> call
+/// 403s. The seeder provisions a <see cref="Andy.Rbac.Models.SubjectType.Service"/>
+/// subject for <see cref="ClientId"/> and binds it (via a generated
+/// <c>service:{clientId}</c> role) to each fully-qualified permission code in
+/// <see cref="Permissions"/> (e.g. <c>"andy-agents:agent:read"</c>). The
+/// permission must be one the OWNING service's manifest declares — least
+/// privilege, no blanket service role.
+/// </summary>
+public sealed record RegistrationServicePrincipal(
+    [property: JsonPropertyName("clientId")]    string ClientId,
+    [property: JsonPropertyName("permissions")] string[]? Permissions
 );
 
 public sealed record RegistrationResourceType(

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -1,5 +1,7 @@
 using Andy.Rbac.Api.Data;
 using Andy.Rbac.Infrastructure.Data;
+using Andy.Rbac.Infrastructure.Repositories;
+using Andy.Rbac.Models;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -364,6 +366,104 @@ public class DataSeederTests
             (await context.Subjects.CountAsync(s => s.ExternalId == DataSeeder.TestUserWellKnownExternalId))
                 .Should().Be(1);
             (await context.SubjectRoles.CountAsync()).Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    // -- service-principal grants (M2M cross-service authz) -----------------
+    //
+    // Regression for the platform-wide M2M authz hole: andy-auth issues
+    // client_credentials tokens with sub=clientId and no email claim, so
+    // EnsureSubjectMiddleware never provisions them — every service-to-service
+    // [RequirePermission] call 403'd ("Subject not found: andy-tasks-api"),
+    // which left the planner's andy-agents catalog fetch empty and produced
+    // agentless tasks. A manifest now declares `rbac.servicePrincipal` and the
+    // seeder provisions a Service subject + a least-privilege role carrying
+    // exactly the declared cross-service permissions.
+
+    private const string SampleManifestWithServicePrincipal = """
+        {
+          "service": {
+            "name": "andy-svcprin-test",
+            "displayName": "Andy ServicePrincipal (Test Manifest)",
+            "description": "Fixture",
+            "embeddedProxyPrefix": "/svcprin"
+          },
+          "rbac": {
+            "applicationCode": "andy-svcprin-test",
+            "applicationName": "Andy ServicePrincipal (Test)",
+            "description": "Fixture for DataSeederTests",
+            "resourceTypes": [
+              { "code": "thing", "name": "Thing", "supportsInstances": false }
+            ],
+            "roles": [
+              { "code": "admin", "name": "Administrator", "isSystem": true }
+            ],
+            "servicePrincipal": {
+              "clientId": "svcprin-test-api",
+              "permissions": ["andy-svcprin-test:thing:read"]
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_WithServicePrincipal_ProvisionsServiceSubjectAndGrantsPermission()
+    {
+        using var context = CreateContext();
+        await DataSeeder.SeedAsync(context); // populates the global Actions catalogue
+        var manifestPath = WriteTempManifest(SampleManifestWithServicePrincipal);
+        try
+        {
+            await DataSeeder.SeedFromManifestsAsync(context, ConfigurationWithManifest(manifestPath), NullLogger.Instance);
+
+            // A Service-typed subject was provisioned for the client id.
+            var subject = await context.Subjects.FirstOrDefaultAsync(s => s.ExternalId == "svcprin-test-api");
+            subject.Should().NotBeNull();
+            subject!.Type.Should().Be(SubjectType.Service);
+            subject.IsActive.Should().BeTrue();
+
+            // …bound via a cross-application service:{clientId} role…
+            var role = await context.Roles.FirstOrDefaultAsync(r => r.Code == "service:svcprin-test-api");
+            role.Should().NotBeNull();
+            role!.ApplicationId.Should().BeNull();
+
+            var assignment = await context.SubjectRoles.FirstOrDefaultAsync(sr => sr.SubjectId == subject.Id && sr.RoleId == role.Id);
+            assignment.Should().NotBeNull();
+
+            // …and the end-to-end check the proxy actually runs now passes.
+            var repo = new PermissionRepository(context);
+            (await repo.HasPermissionAsync(subject.Id, "andy-svcprin-test:thing:read"))
+                .Should().BeTrue();
+            // Least privilege: an undeclared permission is still denied.
+            (await repo.HasPermissionAsync(subject.Id, "andy-svcprin-test:thing:write"))
+                .Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+        }
+    }
+
+    [Fact]
+    public async Task SeedFromManifestsAsync_ServicePrincipal_IsIdempotent()
+    {
+        using var context = CreateContext();
+        await DataSeeder.SeedAsync(context); // populates the global Actions catalogue
+        var manifestPath = WriteTempManifest(SampleManifestWithServicePrincipal);
+        try
+        {
+            await DataSeeder.SeedFromManifestsAsync(context, ConfigurationWithManifest(manifestPath), NullLogger.Instance);
+            await DataSeeder.SeedFromManifestsAsync(context, ConfigurationWithManifest(manifestPath), NullLogger.Instance);
+
+            (await context.Subjects.CountAsync(s => s.ExternalId == "svcprin-test-api")).Should().Be(1);
+            (await context.Roles.CountAsync(r => r.Code == "service:svcprin-test-api")).Should().Be(1);
+            var role = await context.Roles.FirstAsync(r => r.Code == "service:svcprin-test-api");
+            (await context.RolePermissions.CountAsync(rp => rp.RoleId == role.Id)).Should().Be(1);
+            (await context.SubjectRoles.CountAsync(sr => sr.RoleId == role.Id)).Should().Be(1);
         }
         finally
         {


### PR DESCRIPTION
## Problem
andy-auth issues client_credentials (M2M) tokens with `sub=clientId` and no email claim, so `EnsureSubjectMiddleware` deliberately skips them — no service principal ever got an RBAC subject. Every service-to-service `[RequirePermission]` call 403'd with `Subject not found: <client-id>`. This blocked the andy-tasks planner from reading the andy-agents catalog (empty roster → agentless tasks → `TX-DISPATCH-NO-AGENT`), and would block tasks→containers dispatch and the in-container agent the same way.

## Fix
A manifest declares `rbac.servicePrincipal {clientId, permissions[]}` and `DataSeeder.SeedServicePrincipalGrantsAsync` provisions:
- a `SubjectType.Service` subject for the client id,
- a least-privilege cross-application `service:{clientId}` role carrying exactly the declared fully-qualified permissions (no blanket service role),
- the subject→role assignment.

Runs after admin-permission seeding (so the cross-service Permission rows exist) and is idempotent across restarts.

## Tests
- Provisions subject+role+grant; `HasPermissionAsync` returns true for a granted permission, false for an undeclared one (least privilege).
- Idempotent across repeated seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)