### PR TITLE
Seed evaluate/evaluate-task actions so policy-eval permissions materialize (unblocks the 403 gate)

### DIFF
--- a/src/Andy.Rbac.Api/Data/DataSeeder.cs
+++ b/src/Andy.Rbac.Api/Data/DataSeeder.cs
@@ -560,6 +560,16 @@ public static class DataSeeder
             new Action { Code = "execute", Name = "Execute", Description = "Execute or run resource", SortOrder = 6 },
             new Action { Code = "export", Name = "Export", Description = "Export resource data", SortOrder = 7 },
             new Action { Code = "import", Name = "Import", Description = "Import resource data", SortOrder = 8 },
+            // Policy evaluation verbs. andy-policies' manifest declares
+            // `andy-policies:plan:evaluate` (plan-finalize gate) and
+            // `andy-policies:plan:evaluate-task` (per-task/run gate, #1944).
+            // Permissions are materialised as resourceType×action from THIS
+            // global vocabulary, so without these two actions the evaluate
+            // permissions are never created — the andy-tasks service principal
+            // can't be granted them and every evaluate/evaluate-task call from
+            // andy-tasks 403s (blocking plan execution's policy gate).
+            new Action { Code = "evaluate", Name = "Evaluate", Description = "Evaluate resource against policy", SortOrder = 9 },
+            new Action { Code = "evaluate-task", Name = "Evaluate Task", Description = "Evaluate a task/run against policy", SortOrder = 10 },
         };
 
         foreach (var action in actions)

--- a/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
+++ b/tests/Andy.Rbac.Api.Tests/Data/DataSeederTests.cs
@@ -43,6 +43,12 @@ public class DataSeederTests
         actions.Should().Contain(a => a.Code == "execute");
         actions.Should().Contain(a => a.Code == "export");
         actions.Should().Contain(a => a.Code == "import");
+        // Policy-evaluation verbs — without these the resourceType×action
+        // materialisation never creates `andy-policies:plan:evaluate(-task)`,
+        // so andy-tasks' service principal can't be granted them and the
+        // execution-time policy gate 403s.
+        actions.Should().Contain(a => a.Code == "evaluate");
+        actions.Should().Contain(a => a.Code == "evaluate-task");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
Every `POST /api/policies/evaluate-task` from andy-tasks **403**'d (`RbacRequirement` forbidden), silently blocking plan execution's policy gate.

## Root cause
Permissions are materialised as `resourceType × action` from the **fixed global action vocabulary** in `SeedActionsAsync` (`read/write/delete/share/admin/execute/export/import`). andy-policies' manifest declares `andy-policies:plan:evaluate` and `andy-policies:plan:evaluate-task` (#1944), but since `evaluate`/`evaluate-task` weren't in the global set, those permissions were **never created** — so the `service:andy-tasks-api` role binding couldn't find them to grant, and the principal lacked the permission → 403.

## Fix
Add `evaluate` + `evaluate-task` to the action vocabulary. The seed is idempotent, so on the next startup the actions upsert, the `plan:evaluate(-task)` permissions materialise, and the `service:andy-tasks-api` role + subject assignment pick up the grant. **Verified live in the rbac DB after redeploy** — the role now carries `andy-policies:plan:evaluate-task` and the principal is assigned the role.

## Test
`SeedAsync_SeedsActions` extended to assert both actions are present (fails on old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)